### PR TITLE
add ui for teams to self-assign challenge

### DIFF
--- a/components/custom/user-team/ChallengeSelection.tsx
+++ b/components/custom/user-team/ChallengeSelection.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Challenge } from "@/utils/db/schema/challenge";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "sonner";
+
+interface ChallengeSelectionProps {
+  teamId: string;
+  currentChallengeId?: string | null;
+}
+
+export default function ChallengeSelection({
+  teamId,
+  currentChallengeId,
+}: ChallengeSelectionProps) {
+  const [challenges, setChallenges] = useState<Challenge[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedChallengeId, setSelectedChallengeId] = useState<string | null>(
+    currentChallengeId || null,
+  );
+
+  useEffect(() => {
+    const fetchChallenges = async () => {
+      setIsLoading(true);
+      try {
+        const response = await fetch("/api/challenges");
+        if (!response.ok) throw new Error("Failed to fetch challenges");
+        const data = await response.json();
+        setChallenges(data || []);
+      } catch (error) {
+        console.error("Error fetching challenges:", error);
+        toast.error("Failed to fetch challenges");
+      }
+      setIsLoading(false);
+    };
+
+    fetchChallenges();
+  }, []);
+
+  const handleChallengeSelect = async (challengeId: string) => {
+    try {
+      const response = await fetch("/api/challenges", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ teamId, challengeId }),
+      });
+
+      if (!response.ok) throw new Error("Failed to join challenge");
+      setSelectedChallengeId(challengeId);
+      toast.success("Successfully joined challenge");
+    } catch (error) {
+      console.error("Error joining challenge:", error);
+      toast.error("Failed to join challenge");
+    }
+  };
+
+  const handleChallengeLeave = async () => {
+    try {
+      const response = await fetch("/api/challenges", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ teamId }),
+      });
+
+      if (!response.ok) throw new Error("Failed to leave challenge");
+      setSelectedChallengeId(null);
+      toast.success("Successfully left challenge");
+    } catch (error) {
+      console.error("Error leaving challenge:", error);
+      toast.error("Failed to leave challenge");
+    }
+  };
+
+  if (isLoading) {
+    return <div>Loading challenges...</div>;
+  }
+
+  const selectedChallenge = challenges.find((c) => c.id === selectedChallengeId);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-lg font-medium">Challenge Selection</h3>
+        <p className="text-sm text-neutral-500">
+          Select a challenge for your team to participate in.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Select
+          value={selectedChallengeId || ""}
+          onValueChange={handleChallengeSelect}
+          disabled={challenges.length === 0}
+        >
+          <SelectTrigger className="w-[300px]">
+            <SelectValue placeholder="Select a challenge" />
+          </SelectTrigger>
+          <SelectContent>
+            {challenges.map((challenge) => (
+              <SelectItem key={challenge.id} value={challenge.id}>
+                {challenge.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {selectedChallengeId && (
+          <Button variant="outline" onClick={handleChallengeLeave}>
+            Leave Challenge
+          </Button>
+        )}
+      </div>
+
+      {selectedChallenge && (
+        <div className="rounded-lg border p-4">
+          <h4 className="font-medium">{selectedChallenge.name}</h4>
+          <p className="mt-1 text-sm text-neutral-500">{selectedChallenge.description}</p>
+          {selectedChallenge.metadata && (
+            <div className="mt-2 text-sm">
+              <p>
+                <span className="font-medium">Team Quota: </span>
+                {(selectedChallenge.metadata as { teamQuota?: number })?.teamQuota || "No quota"}
+              </p>
+              {(selectedChallenge.metadata as { judges?: string[] })?.judges && (
+                <p>
+                  <span className="font-medium">Judges: </span>
+                  {(selectedChallenge.metadata as { judges?: string[] }).judges?.join(", ")}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/custom/user-team/TeamManagementSection.tsx
+++ b/components/custom/user-team/TeamManagementSection.tsx
@@ -5,6 +5,7 @@ import TeamManagement from "./TeamManagement";
 import { Team } from "@/app/services/team";
 import { Suspense } from "react";
 import SuspenseLoadingSpinner from "../SuspenseLoadingSpinner";
+import ChallengeSelection from "./ChallengeSelection";
 
 export default async function TeamManagementSection({
   userTeam,
@@ -39,6 +40,12 @@ export default async function TeamManagementSection({
       <div className="mt-2">
         <Suspense key={`members-${teamKey}`} fallback={<SuspenseLoadingSpinner />}>
           <AddMembers teamId={userTeam.id} numMembers={userTeam.users.length} />
+        </Suspense>
+      </div>
+
+      <div className="mt-4">
+        <Suspense key={`challenge-${teamKey}`} fallback={<SuspenseLoadingSpinner />}>
+          <ChallengeSelection teamId={userTeam.id} currentChallengeId={userTeam.challengeId} />
         </Suspense>
       </div>
     </div>


### PR DESCRIPTION
### TL;DR
Added a new Challenge Selection component to allow teams to join and leave challenges.

![CleanShot 2025-02-05 at 14.10.31@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GNKlOysjLXG1QUlNa868/cead9aef-3d5e-4491-a33c-99379c4998e4.png)

### What changed?
- Created a new `ChallengeSelection` component that displays available challenges
- Added functionality to join and leave challenges
- Integrated challenge selection into the team management section
- Added challenge details display showing name, description, team quota, and judges
- Implemented toast notifications for success/error states

### How to test?
1. Navigate to the team management section
2. Verify the challenge selection dropdown appears
3. Select a challenge and confirm the join action works
4. Check that challenge details are displayed correctly
5. Test the leave challenge functionality
6. Verify error states by simulating failed API calls

### Why make this change?
To enable teams to participate in challenges through a user-friendly interface, providing clear visibility of challenge details and simple management of challenge participation.