### PR TITLE
add challenges section ui on admin portal, and challenge statistics page

### DIFF
--- a/app/admin/challenges/page.tsx
+++ b/app/admin/challenges/page.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import { createClient } from "@/utils/supabase/client";
+import { toast } from "sonner";
+
+interface ChallengeStats {
+  id: string;
+  name: string;
+  teamCount: number;
+  teamQuota: number | null;
+}
+
+export default function ChallengeDashboard() {
+  const [stats, setStats] = useState<ChallengeStats[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const supabase = createClient();
+
+  const fetchStats = async () => {
+    try {
+      const response = await fetch("/api/admin/challenges/stats");
+      if (!response.ok) throw new Error("Failed to fetch challenge statistics");
+      const result = await response.json();
+      setStats(result);
+    } catch (error) {
+      console.error("Error fetching challenge stats:", error);
+      toast.error("Failed to fetch challenge statistics");
+    }
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    fetchStats();
+
+    // Subscribe to team changes
+    const channel = supabase
+      .channel("team_changes")
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "team",
+        },
+        () => {
+          fetchStats();
+        },
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [supabase]);
+
+  if (isLoading) {
+    return <div>Loading challenge statistics...</div>;
+  }
+
+  return (
+    <div className="container mx-auto p-8">
+      <h1 className="mb-8 text-3xl font-bold">Challenge Statistics</h1>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        {stats.map((stat) => (
+          <Card key={stat.id}>
+            <CardHeader>
+              <CardTitle>{stat.name}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">
+                {stat.teamCount} / {stat.teamQuota || "∞"}
+              </div>
+              <p className="text-xs text-muted-foreground">Teams registered</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card className="mt-8">
+        <CardHeader>
+          <CardTitle>Team Distribution</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-[400px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={stats}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="teamCount" fill="#3b82f6" name="Teams" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/api/admin/challenges/route.ts
+++ b/app/api/admin/challenges/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import {
+  createChallenge,
+  deleteChallenge,
+  getAllChallenges,
+  updateChallenge,
+} from "@/app/services/challenge";
+
+export async function GET() {
+  try {
+    const challenges = await getAllChallenges();
+    return NextResponse.json(challenges);
+  } catch (error) {
+    console.error("Error fetching challenges:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch challenges" },
+      {
+        status: 500,
+      },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const challenge = await request.json();
+    const result = await createChallenge(challenge);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error creating challenge:", error);
+    return NextResponse.json(
+      { error: "Failed to create challenge" },
+      {
+        status: 500,
+      },
+    );
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const { id, ...data } = await request.json();
+    if (!id) {
+      return NextResponse.json(
+        { error: "Challenge ID is required" },
+        {
+          status: 400,
+        },
+      );
+    }
+
+    const result = await updateChallenge(id, data);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error updating challenge:", error);
+    return NextResponse.json(
+      { error: "Failed to update challenge" },
+      {
+        status: 500,
+      },
+    );
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const { id } = await request.json();
+    if (!id) {
+      return NextResponse.json(
+        { error: "Challenge ID is required" },
+        {
+          status: 400,
+        },
+      );
+    }
+
+    const result = await deleteChallenge(id);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error deleting challenge:", error);
+    return NextResponse.json(
+      { error: "Failed to delete challenge" },
+      {
+        status: 500,
+      },
+    );
+  }
+}

--- a/app/api/admin/challenges/stats/route.ts
+++ b/app/api/admin/challenges/stats/route.ts
@@ -1,0 +1,17 @@
+import { getChallengeStats } from "@/app/services/challenge";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+    try {
+        const stats = await getChallengeStats();
+        return NextResponse.json(stats);
+    } catch (error) {
+        console.error("Error fetching challenge stats:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch challenge statistics" },
+            {
+                status: 500,
+            },
+        );
+    }
+}

--- a/app/services/challenge.ts
+++ b/app/services/challenge.ts
@@ -1,0 +1,88 @@
+import { db } from "@/utils/db";
+import { Challenge, challenges, NewChallenge } from "@/utils/db/schema/challenge";
+import { eq } from "drizzle-orm";
+import { team } from "@/utils/db/schema/team";
+
+interface ChallengeMetadata {
+  judges?: string[];
+  teamQuota?: number;
+  [key: string]: unknown;
+}
+
+export async function getAllChallenges() {
+  return await db.query.challenges.findMany({
+    with: {
+      teams: true,
+    },
+  });
+}
+
+export async function getChallengeById(id: string) {
+  return await db.query.challenges.findFirst({
+    where: eq(challenges.id, id),
+    with: {
+      teams: true,
+    },
+  });
+}
+
+export async function createChallenge(challenge: NewChallenge) {
+  const [newChallenge] = await db.insert(challenges).values(challenge).returning();
+  return newChallenge;
+}
+
+export async function updateChallenge(id: string, challenge: Partial<Challenge>) {
+  const [updatedChallenge] = await db
+    .update(challenges)
+    .set({ ...challenge, updatedAt: "NOW()" })
+    .where(eq(challenges.id, id))
+    .returning();
+  return updatedChallenge;
+}
+
+export async function deleteChallenge(id: string) {
+  const [deletedChallenge] = await db.delete(challenges).where(eq(challenges.id, id)).returning();
+  return deletedChallenge;
+}
+
+export async function assignTeamToChallenge(teamId: string, challengeId: string) {
+  const [updatedTeam] = await db
+    .update(team)
+    .set({ challengeId })
+    .where(eq(team.id, teamId))
+    .returning();
+  return updatedTeam;
+}
+
+export async function removeTeamFromChallenge(teamId: string) {
+  const [updatedTeam] = await db
+    .update(team)
+    .set({ challengeId: null })
+    .where(eq(team.id, teamId))
+    .returning();
+  return updatedTeam;
+}
+
+export async function getTeamsByChallenge(challengeId: string) {
+  return await db.query.challenges.findFirst({
+    where: eq(challenges.id, challengeId),
+    with: {
+      teams: true,
+    },
+  });
+}
+
+export async function getChallengeStats() {
+  const allChallenges = await db.query.challenges.findMany({
+    with: {
+      teams: true,
+    },
+  });
+
+  return allChallenges.map((challenge) => ({
+    id: challenge.id,
+    name: challenge.name,
+    teamCount: challenge.teams.length,
+    teamQuota: (challenge.metadata as ChallengeMetadata)?.teamQuota || null,
+  }));
+}

--- a/components/custom/admin/AdminClient.tsx
+++ b/components/custom/admin/AdminClient.tsx
@@ -37,8 +37,11 @@ import { Check, ChevronsUpDown, Search, Loader2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { UserActions } from "./UserActions";
 import { toast, Toaster } from "sonner";
+import ChallengeManagement from "./ChallengeManagement";
 
 const ITEMS_PER_PAGE = 10;
+
+// #region UserTable
 
 interface UserTableProps {
   users: UserInfo[];
@@ -124,6 +127,8 @@ function Pagination({ totalPages, currentPage, onPageChange }: PaginationProps) 
     </div>
   );
 }
+
+// #endregion
 
 type SearchType = "username" | "email" | "team";
 const SEARCH_TYPE_LABELS: Record<SearchType, string> = {
@@ -258,84 +263,9 @@ export default function AdminClient() {
       <Toaster />
       <div>
         <h1 className="mb-4 text-2xl font-bold md:text-4xl">HackOMania 2025 Admin Portal</h1>
-        <div className="flex flex-col gap-4">
-          <form
-            onSubmit={async (e) => {
-              e.preventDefault();
-              const formData = new FormData(e.currentTarget);
-              setIsUploading(true);
-              try {
-                const result = await uploadFile(formData);
-                if (result.error) {
-                  toast.error(result.error);
-                } else {
-                  toast.success("CSV uploaded successfully");
-                  await fetchUsers(); // Refresh the user list after upload
-                }
-              } catch (error) {
-                toast.error(`Failed to upload CSV: ${error}`);
-              } finally {
-                setIsUploading(false);
-              }
-            }}
-          >
-            <div className="flex items-center gap-2">
-              <span>Main Event Registrations</span>
-              <Input
-                type="file"
-                name="file"
-                accept=".xlsx,.xls,.csv"
-                className="max-w-xs"
-                disabled={isUploading}
-                required
-              />
-              <Button type="submit" variant="outline" disabled={isUploading}>
-                {isUploading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Uploading...
-                  </>
-                ) : (
-                  "Upload CSV"
-                )}
-              </Button>
-            </div>
-          </form>
-          <form
-            onSubmit={async (e) => {
-              e.preventDefault();
-              setIsSyncing(true);
-              try {
-                const result = await syncEventbrite();
-                if (result.error) {
-                  toast.error(result.error);
-                } else {
-                  toast.success("Synced with Eventbrite successfully");
-                  await fetchUsers();
-                }
-              } catch (error) {
-                toast.error(`Failed to sync with Eventbrite: ${error}`);
-              } finally {
-                setIsSyncing(false);
-              }
-            }}
-          >
-            <div className="flex items-center gap-2">
-              <span>Pre-event Registrations</span>
-              <Button type="submit" variant="outline" disabled={isSyncing}>
-                {isSyncing ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Syncing...
-                  </>
-                ) : (
-                  "Sync from Eventbrite"
-                )}
-              </Button>
-            </div>
-          </form>
-        </div>
       </div>
+
+      <ChallengeManagement />
 
       <div className="rounded-lg border border-neutral-400 p-4">
         <div className="mb-4">
@@ -345,6 +275,87 @@ export default function AdminClient() {
               <span className="text-sm text-neutral-500">({filteredUsers.length})</span>
             )}
           </h2>
+
+          <div className="mb-6 space-y-4">
+            <form
+              onSubmit={async (e) => {
+                e.preventDefault();
+                const formData = new FormData(e.currentTarget);
+                setIsUploading(true);
+                try {
+                  const result = await uploadFile(formData);
+                  if (result.error) {
+                    toast.error(result.error);
+                  } else {
+                    toast.success("CSV uploaded successfully");
+                    await fetchUsers(); // Refresh the user list after upload
+                  }
+                } catch (error) {
+                  toast.error(`Failed to upload CSV: ${error}`);
+                } finally {
+                  setIsUploading(false);
+                }
+              }}
+            >
+              <div className="flex items-center gap-2">
+                <span>Main Event Registrations</span>
+                <Input
+                  type="file"
+                  name="file"
+                  accept=".xlsx,.xls,.csv"
+                  className="max-w-xs"
+                  disabled={isUploading}
+                  required
+                />
+                <Button type="submit" variant="outline" disabled={isUploading}>
+                  {isUploading ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Uploading...
+                    </>
+                  ) : (
+                    "Upload CSV"
+                  )}
+                </Button>
+              </div>
+            </form>
+
+            <form
+              onSubmit={async (e) => {
+                e.preventDefault();
+                setIsSyncing(true);
+                try {
+                  const result = await syncEventbrite();
+                  if (result.error) {
+                    toast.error(result.error);
+                  } else {
+                    toast.success("Synced with Eventbrite successfully");
+                    await fetchUsers();
+                  }
+                } catch (error) {
+                  toast.error(`Failed to sync with Eventbrite: ${error}`);
+                } finally {
+                  setIsSyncing(false);
+                }
+              }}
+            >
+              <div className="flex items-center gap-2">
+                <span>Pre-event Registrations</span>
+                <Button type="submit" variant="outline" disabled={isSyncing}>
+                  {isSyncing ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Syncing...
+                    </>
+                  ) : (
+                    "Sync from Eventbrite"
+                  )}
+                </Button>
+              </div>
+            </form>
+            <hr className="w-full" />
+          </div>
+
           {!isLoading && (
             <div className="flex items-center gap-2">
               <label htmlFor="search-type">Search by:</label>

--- a/components/custom/admin/ChallengeManagement.tsx
+++ b/components/custom/admin/ChallengeManagement.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Challenge, ChallengeMetadata } from "@/types/challenge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
+
+interface EditChallengeFormData {
+  name: string;
+  description: string;
+  metadata: ChallengeMetadata;
+}
+
+export default function ChallengeManagement() {
+  const [challenges, setChallenges] = useState<Challenge[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [newChallenge, setNewChallenge] = useState({
+    name: "",
+    description: "",
+    metadata: { teamQuota: 0 },
+  });
+  const [editData, setEditData] = useState<EditChallengeFormData | null>(null);
+  const [editingChallengeId, setEditingChallengeId] = useState<string | null>(null);
+
+  const fetchChallenges = async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch("/api/admin/challenges");
+      if (!response.ok) throw new Error("Failed to fetch challenges");
+      const data = await response.json();
+      setChallenges(data || []);
+    } catch (error) {
+      console.error("Error fetching challenges:", error);
+      toast.error("Failed to fetch challenges");
+    }
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    fetchChallenges();
+  }, []);
+
+  const handleCreateChallenge = async () => {
+    try {
+      const response = await fetch("/api/admin/challenges", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(newChallenge),
+      });
+
+      if (!response.ok) throw new Error("Failed to create challenge");
+      toast.success("Challenge created successfully");
+      fetchChallenges();
+      setNewChallenge({ name: "", description: "", metadata: { teamQuota: 0 } });
+    } catch (error) {
+      console.error("Error creating challenge:", error);
+      toast.error("Failed to create challenge");
+    }
+  };
+
+  const handleUpdateChallenge = async () => {
+    if (!editingChallengeId || !editData) return;
+
+    try {
+      const response = await fetch("/api/admin/challenges", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: editingChallengeId, ...editData }),
+      });
+
+      if (!response.ok) throw new Error("Failed to update challenge");
+      toast.success("Challenge updated successfully");
+      fetchChallenges();
+      setEditingChallengeId(null);
+      setEditData(null);
+    } catch (error) {
+      console.error("Error updating challenge:", error);
+      toast.error("Failed to update challenge");
+    }
+  };
+
+  const startEditing = (challenge: Challenge) => {
+    setEditingChallengeId(challenge.id);
+    setEditData({
+      name: challenge.name,
+      description: challenge.description,
+      metadata: challenge.metadata || { teamQuota: 0 },
+    });
+  };
+
+  const cancelEditing = () => {
+    setEditingChallengeId(null);
+    setEditData(null);
+  };
+
+  return (
+    <div className="rounded-lg border border-neutral-400 p-4">
+      <div className="mb-4">
+        <h2 className="mb-4 text-xl font-semibold">
+          Challenges{" "}
+          {challenges.length > 0 && (
+            <span className="text-sm text-neutral-500">({challenges.length})</span>
+          )}
+        </h2>
+
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="outline">Create New Challenge</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Create New Challenge</DialogTitle>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label htmlFor="name">Name</Label>
+                <Input
+                  id="name"
+                  value={newChallenge.name}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setNewChallenge({ ...newChallenge, name: e.target.value })
+                  }
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="description">Description</Label>
+                <Textarea
+                  id="description"
+                  value={newChallenge.description}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                    setNewChallenge({ ...newChallenge, description: e.target.value })
+                  }
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="teamQuota">Team Quota</Label>
+                <Input
+                  id="teamQuota"
+                  type="number"
+                  value={newChallenge.metadata.teamQuota}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setNewChallenge({
+                      ...newChallenge,
+                      metadata: { ...newChallenge.metadata, teamQuota: parseInt(e.target.value) },
+                    })
+                  }
+                />
+              </div>
+              <Button onClick={handleCreateChallenge}>Create Challenge</Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {isLoading ? (
+        <div>Loading challenges...</div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead>Team Quota</TableHead>
+              <TableHead>Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {challenges.map((challenge) => (
+              <TableRow key={challenge.id}>
+                <TableCell>{challenge.name}</TableCell>
+                <TableCell>{challenge.description}</TableCell>
+                <TableCell>
+                  {(challenge.metadata as ChallengeMetadata)?.teamQuota || "No quota"}
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-2">
+                    <Dialog
+                      open={editingChallengeId === challenge.id}
+                      onOpenChange={(open) => !open && cancelEditing()}
+                    >
+                      <DialogTrigger asChild>
+                        <Button variant="outline" size="sm" onClick={() => startEditing(challenge)}>
+                          Edit
+                        </Button>
+                      </DialogTrigger>
+                      <DialogContent>
+                        <DialogHeader>
+                          <DialogTitle>Edit Challenge</DialogTitle>
+                        </DialogHeader>
+                        {editData && (
+                          <div className="grid gap-4 py-4">
+                            <div className="grid gap-2">
+                              <Label htmlFor="name">Name</Label>
+                              <Input
+                                id="name"
+                                value={editData.name}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                  setEditData({ ...editData, name: e.target.value })
+                                }
+                              />
+                            </div>
+                            <div className="grid gap-2">
+                              <Label htmlFor="description">Description</Label>
+                              <Textarea
+                                id="description"
+                                value={editData.description}
+                                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                                  setEditData({ ...editData, description: e.target.value })
+                                }
+                              />
+                            </div>
+                            <div className="grid gap-2">
+                              <Label htmlFor="teamQuota">Team Quota</Label>
+                              <Input
+                                id="teamQuota"
+                                type="number"
+                                value={editData.metadata.teamQuota}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                  setEditData({
+                                    ...editData,
+                                    metadata: {
+                                      ...editData.metadata,
+                                      teamQuota: parseInt(e.target.value),
+                                    },
+                                  })
+                                }
+                              />
+                            </div>
+                            <div className="flex justify-end gap-2">
+                              <Button variant="outline" onClick={cancelEditing}>
+                                Cancel
+                              </Button>
+                              <Button onClick={handleUpdateChallenge}>Save Changes</Button>
+                            </div>
+                          </div>
+                        )}
+                      </DialogContent>
+                    </Dialog>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/components/custom/user-team/ChallengeSelection.tsx
+++ b/components/custom/user-team/ChallengeSelection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Challenge } from "@/utils/db/schema/challenge";
+import { Challenge } from "@/types/challenge";
 import { Button } from "@/components/ui/button";
 import {
   Select,

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  ),
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  ),
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  ),
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  ),
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  ),
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.54.2",
     "react-icons": "^5.4.0",
+    "recharts": "^2.15.1",
     "sonner": "^1.7.3",
     "tailwindcss-intersect": "^2.0.1",
     "zod": "^3.24.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       react-icons:
         specifier: ^5.4.0
         version: 5.4.0(react@18.2.0)
+      recharts:
+        specifier: ^2.15.1
+        version: 2.15.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       sonner:
         specifier: ^1.7.3
         version: 1.7.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1301,6 +1304,33 @@ packages:
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
+  '@types/d3-array@3.2.1':
+    resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
@@ -1618,6 +1648,50 @@ packages:
   csv-parse@5.6.0:
     resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1650,6 +1724,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1681,6 +1758,9 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
@@ -1995,6 +2075,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -2007,6 +2090,10 @@ packages:
 
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-equals@5.2.2:
+    resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2229,6 +2316,10 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -2443,6 +2534,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -2847,6 +2941,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -2877,6 +2974,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -2886,6 +2989,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
 
   react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -2897,6 +3006,16 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.1:
+    resolution: {integrity: sha512-v8PUTUlyiDe56qUj82w/EDVuzEFXwEHp9/xOowGAZwfLjB9uAy3GllQVIYMWF6nU+qibx85WF75zD7AjqoT54Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -3168,6 +3287,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -3260,6 +3382,9 @@ packages:
 
   vanilla-swipe@2.4.1:
     resolution: {integrity: sha512-o6pfI0dipet88ZnPLV4Jx04Ia+U3xANh14vhROW2TOe/mrwk2JGG68+Z0BPoD1YUcQQEnK4SZBXkqFe+K1l7/w==}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -4299,6 +4424,30 @@ snapshots:
 
   '@types/cookie@0.6.0': {}
 
+  '@types/d3-array@3.2.1': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/json5@0.0.29': {}
 
   '@types/node@20.10.6':
@@ -4671,6 +4820,44 @@ snapshots:
 
   csv-parse@5.6.0: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.0: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -4698,6 +4885,8 @@ snapshots:
   debug@4.4.0:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-is@0.1.4: {}
 
@@ -4729,6 +4918,11 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.26.7
+      csstype: 3.1.3
 
   dotenv@16.4.7: {}
 
@@ -5143,6 +5337,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.1: {}
 
   execa@8.0.1:
@@ -5160,6 +5356,8 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
+
+  fast-equals@5.2.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -5381,6 +5579,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -5612,6 +5812,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.17.21: {}
 
   log-update@6.1.0:
     dependencies:
@@ -5929,6 +6131,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@18.3.1: {}
+
   react-remove-scroll-bar@2.3.8(@types/react@18.2.46)(react@18.2.0):
     dependencies:
       react: 18.2.0
@@ -5959,6 +6163,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.46
 
+  react-smooth@4.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      fast-equals: 5.2.2
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-transition-group: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+
   react-style-singleton@2.2.3(@types/react@18.2.46)(react@18.2.0):
     dependencies:
       get-nonce: 1.0.1
@@ -5966,6 +6178,15 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.2.46
+
+  react-transition-group@4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@babel/runtime': 7.26.7
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   react@18.2.0:
     dependencies:
@@ -5978,6 +6199,23 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6338,6 +6576,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -6437,6 +6677,23 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   vanilla-swipe@2.4.1: {}
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.1
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   webidl-conversions@3.0.1: {}
 

--- a/types/challenge.ts
+++ b/types/challenge.ts
@@ -1,0 +1,15 @@
+export interface ChallengeMetadata {
+  judges?: string[];
+  teamQuota?: number;
+  references?: string[];
+  [key: string]: unknown;
+}
+
+export interface Challenge {
+  id: string;
+  name: string;
+  description: string;
+  metadata: ChallengeMetadata | null;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
### TL;DR

Added challenge management functionality to the admin portal, including a dashboard with real-time statistics and CRUD operations for challenges.

![CleanShot 2025-02-05 at 17.37.48@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GNKlOysjLXG1QUlNa868/7403bef5-406f-43e7-8de9-e0a9b65d00b9.png)

![CleanShot 2025-02-05 at 17.38.08@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GNKlOysjLXG1QUlNa868/e9ff1d4a-96ca-43dd-9385-c43f8126d226.png)

### What changed?

- Created a new challenge dashboard with real-time team registration statistics
- Added a bar chart visualization showing team distribution across challenges
- Implemented CRUD API endpoints for managing challenges
- Added challenge management UI with create/edit/delete capabilities
- Created challenge service layer for database operations
- Added team quota tracking and monitoring

### How to test?

1. Navigate to the admin portal
2. Access the challenge management section
3. Try creating a new challenge with a name, description, and team quota
4. Edit an existing challenge to modify its details
5. View the challenge statistics dashboard to see team distribution
6. Verify real-time updates when teams register for challenges

### Why make this change?

To provide administrators with tools to manage hackathon challenges effectively and monitor team registrations in real-time. This helps organizers track challenge popularity, manage capacity limits, and ensure even distribution of teams across different challenges.