### PR TITLE
implement tabs for challenges, teams and users

### DIFF
--- a/components/custom/admin/UserManagement.tsx
+++ b/components/custom/admin/UserManagement.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { UserInfo } from "@/app/services/user";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Check, ChevronsUpDown, Search, Loader2, X } from "lucide-react";
+import { UserActions } from "./UserActions";
+
+const ITEMS_PER_PAGE = 10;
+
+type SearchType = "username" | "email" | "team";
+const SEARCH_TYPE_LABELS: Record<SearchType, string> = {
+  username: "GitHub Username",
+  email: "Email",
+  team: "Team",
+};
+
+interface UserTableProps {
+  users: UserInfo[];
+  onSetTeamLeader: (userId: string) => Promise<void>;
+  onRemoveUser: (userId: string) => Promise<void>;
+  onEditUser: (userId: string, data: Partial<UserInfo>) => Promise<void>;
+  onNavigateToTeam: (teamName: string) => void;
+  onNavigateToUser: (username: string) => void;
+}
+
+function UserTable({
+  users,
+  onSetTeamLeader,
+  onRemoveUser,
+  onEditUser,
+  onNavigateToTeam,
+  onNavigateToUser,
+}: UserTableProps) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>GitHub Username</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead>Team</TableHead>
+          <TableHead>Team Role</TableHead>
+          <TableHead>Role</TableHead>
+          <TableHead>Pre-event</TableHead>
+          <TableHead className="w-[50px]">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {users.map((user) => (
+          <TableRow key={user.id}>
+            <TableCell>
+              <button
+                onClick={() => onNavigateToUser(user.githubUsername)}
+                className="text-blue-600 hover:underline"
+              >
+                {user.githubUsername}
+              </button>
+            </TableCell>
+            <TableCell>{user.email}</TableCell>
+            <TableCell>
+              {user.teamName ? (
+                <button
+                  onClick={() => onNavigateToTeam(user.teamName!)}
+                  className="text-blue-600 hover:underline"
+                >
+                  {user.teamName}
+                </button>
+              ) : (
+                "No team"
+              )}
+            </TableCell>
+            <TableCell>
+              {user.teamRole ? (
+                <span className={user.teamRole === "leader" ? "font-medium text-blue-600" : ""}>
+                  {user.teamRole.charAt(0).toUpperCase() + user.teamRole.slice(1)}
+                </span>
+              ) : (
+                "-"
+              )}
+            </TableCell>
+            <TableCell>{user.role}</TableCell>
+            <TableCell className={user.preEventRegistered ? "text-green-600" : "text-red-600"}>
+              {user.preEventRegistered ? "✓" : "✗"}
+            </TableCell>
+            <TableCell>
+              <UserActions
+                user={user}
+                onSetTeamLeader={onSetTeamLeader}
+                onRemoveUser={onRemoveUser}
+                onEditUser={onEditUser}
+              />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+interface PaginationProps {
+  totalPages: number;
+  currentPage: number;
+  onPageChange: (page: number) => void;
+}
+
+function Pagination({ totalPages, currentPage, onPageChange }: PaginationProps) {
+  return (
+    <div className="flex items-center justify-center gap-2">
+      <Button
+        variant="outline"
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+      >
+        Previous
+      </Button>
+      <span>
+        Page {currentPage} of {totalPages}
+      </span>
+      <Button
+        variant="outline"
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+      >
+        Next
+      </Button>
+    </div>
+  );
+}
+
+interface UserManagementProps {
+  users: UserInfo[];
+  isLoading: boolean;
+  isUploading: boolean;
+  isSyncing: boolean;
+  searchType: SearchType;
+  searchQuery: string;
+  onSearchTypeChange: (type: SearchType) => void;
+  onSearchQueryChange: (query: string) => void;
+  onUploadFile: (formData: FormData) => Promise<void>;
+  onSyncEventbrite: () => Promise<void>;
+  onSetTeamLeader: (userId: string) => Promise<void>;
+  onRemoveUser: (userId: string) => Promise<void>;
+  onEditUser: (userId: string, data: Partial<UserInfo>) => Promise<void>;
+  onNavigateToTeam: (teamName: string) => void;
+  onNavigateToUser: (username: string) => void;
+}
+
+export default function UserManagement({
+  users,
+  isLoading,
+  isUploading,
+  isSyncing,
+  searchType,
+  searchQuery,
+  onSearchTypeChange,
+  onSearchQueryChange,
+  onUploadFile,
+  onSyncEventbrite,
+  onSetTeamLeader,
+  onRemoveUser,
+  onEditUser,
+  onNavigateToTeam,
+  onNavigateToUser,
+}: UserManagementProps) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  // Filter users based on search
+  const filteredUsers = useMemo(() => {
+    if (!searchQuery) return users;
+
+    return users.filter((user) => {
+      const query = searchQuery.toLowerCase();
+      switch (searchType) {
+        case "username":
+          return user.githubUsername.toLowerCase().includes(query);
+        case "email":
+          return user.email.toLowerCase().includes(query);
+        case "team":
+          return user.teamName?.toLowerCase().includes(query);
+        default:
+          return true;
+      }
+    });
+  }, [users, searchQuery, searchType]);
+
+  // Count non-admin users
+  const nonAdminUsersCount = useMemo(() => {
+    return filteredUsers.filter((user) => user.role !== "admin").length;
+  }, [filteredUsers]);
+
+  const totalPages = Math.ceil(filteredUsers.length / ITEMS_PER_PAGE);
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const endIndex = startIndex + ITEMS_PER_PAGE;
+  const displayedUsers = filteredUsers.slice(startIndex, endIndex);
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    window.scrollTo(0, 0);
+  };
+
+  // Get unique teams for team search
+  const uniqueTeams = useMemo(() => {
+    const teams = new Set<string>();
+    users.forEach((user) => {
+      if (user.teamName) teams.add(user.teamName);
+    });
+    return Array.from(teams).sort();
+  }, [users]);
+
+  return (
+    <div className="rounded-lg border border-neutral-400 p-4">
+      <div className="mb-4">
+        <h2 className="mb-4 text-xl font-semibold">
+          Users{" "}
+          {filteredUsers.length > 0 && (
+            <span className="text-sm text-neutral-500">({nonAdminUsersCount})</span>
+          )}
+        </h2>
+
+        <div className="mb-6 space-y-4">
+          <form
+            onSubmit={async (e) => {
+              e.preventDefault();
+              const formData = new FormData(e.currentTarget);
+              await onUploadFile(formData);
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <span>Main Event Registrations</span>
+              <Input
+                type="file"
+                name="file"
+                accept=".xlsx,.xls,.csv"
+                className="max-w-xs"
+                disabled={isUploading}
+                required
+              />
+              <Button type="submit" variant="outline" disabled={isUploading}>
+                {isUploading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Uploading...
+                  </>
+                ) : (
+                  "Upload CSV"
+                )}
+              </Button>
+            </div>
+          </form>
+
+          <form
+            onSubmit={async (e) => {
+              e.preventDefault();
+              await onSyncEventbrite();
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <span>Pre-event Registrations</span>
+              <Button type="submit" variant="outline" disabled={isSyncing}>
+                {isSyncing ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Syncing...
+                  </>
+                ) : (
+                  "Sync from Eventbrite"
+                )}
+              </Button>
+            </div>
+          </form>
+          <hr className="w-full" />
+        </div>
+
+        {!isLoading && (
+          <div className="flex items-center gap-2">
+            <label htmlFor="search-type">Search by:</label>
+            {/* Search type dropdown */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" className="w-[180px] justify-between">
+                  {SEARCH_TYPE_LABELS[searchType]}
+                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                {Object.entries(SEARCH_TYPE_LABELS).map(([type, label]) => (
+                  <DropdownMenuItem
+                    key={type}
+                    onSelect={() => {
+                      onSearchTypeChange(type as SearchType);
+                      onSearchQueryChange("");
+                    }}
+                  >
+                    <Check
+                      className={`mr-2 h-4 w-4 ${
+                        type === searchType ? "opacity-100" : "opacity-0"
+                      }`}
+                    />
+                    {label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {/* Search input */}
+            <Popover open={searchOpen} onOpenChange={setSearchOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={searchOpen}
+                  className="w-[300px] justify-between"
+                >
+                  {searchQuery || `Search by ${SEARCH_TYPE_LABELS[searchType].toLowerCase()}...`}
+                  <div className="flex items-center">
+                    {searchQuery && (
+                      <div
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onSearchQueryChange("");
+                        }}
+                        className="mr-2 cursor-pointer text-neutral-500 hover:text-neutral-700"
+                      >
+                        <X className="h-4 w-4" />
+                      </div>
+                    )}
+                    <Search className="h-4 w-4 shrink-0 opacity-50" />
+                  </div>
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[300px] p-0">
+                <Command>
+                  <div className="relative">
+                    <CommandInput
+                      placeholder={`Search by ${SEARCH_TYPE_LABELS[searchType].toLowerCase()}...`}
+                      value={searchQuery}
+                      onValueChange={onSearchQueryChange}
+                    />
+                    {searchQuery && (
+                      <div
+                        onClick={() => onSearchQueryChange("")}
+                        className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer text-neutral-500 hover:text-neutral-700"
+                      >
+                        <X className="h-4 w-4" />
+                      </div>
+                    )}
+                  </div>
+                  <CommandList>
+                    <CommandEmpty>No results found.</CommandEmpty>
+                    <CommandGroup>
+                      {searchType === "team" &&
+                        uniqueTeams.map((team) => (
+                          <CommandItem
+                            key={`team-${team}`}
+                            value={team}
+                            onSelect={(value) => {
+                              onSearchQueryChange(value);
+                              setSearchOpen(false);
+                            }}
+                          >
+                            {team}
+                          </CommandItem>
+                        ))}
+                      {searchType === "username" &&
+                        users.map((user) => (
+                          <CommandItem
+                            key={`username-${user.id}`}
+                            value={user.githubUsername}
+                            onSelect={(value) => {
+                              onSearchQueryChange(value);
+                              setSearchOpen(false);
+                            }}
+                          >
+                            {user.githubUsername}
+                          </CommandItem>
+                        ))}
+                      {searchType === "email" &&
+                        users.map((user) => (
+                          <CommandItem
+                            key={`email-${user.id}`}
+                            value={user.email}
+                            onSelect={(value) => {
+                              onSearchQueryChange(value);
+                              setSearchOpen(false);
+                            }}
+                          >
+                            {user.email}
+                          </CommandItem>
+                        ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+          </div>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div>Loading users...</div>
+      ) : (
+        <>
+          <UserTable
+            users={displayedUsers}
+            onSetTeamLeader={onSetTeamLeader}
+            onRemoveUser={onRemoveUser}
+            onEditUser={onEditUser}
+            onNavigateToTeam={onNavigateToTeam}
+            onNavigateToUser={onNavigateToUser}
+          />
+          <div className="mt-4">
+            <Pagination
+              totalPages={totalPages}
+              currentPage={currentPage}
+              onPageChange={handlePageChange}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import { cn } from "@/lib/utils";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-popover": "^1.1.5",
     "@radix-ui/react-select": "^2.1.5",
     "@radix-ui/react-slot": "^1.1.1",
+    "@radix-ui/react-tabs": "^1.1.2",
     "@supabase/ssr": "latest",
     "@supabase/supabase-js": "latest",
     "autoprefixer": "10.4.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.1
         version: 1.1.1(@types/react@18.2.46)(react@18.2.0)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@supabase/ssr':
         specifier: latest
         version: 0.5.2(@supabase/supabase-js@2.47.12)
@@ -1145,6 +1148,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.2':
+    resolution: {integrity: sha512-9u/tQJMcC2aGq7KXpGivMm1mgq7oRJKXphDwdypPd/j21j/2znamPU8WkXgnhUaTrSFNIt8XhOyCAupg8/GbwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.0.1':
@@ -4277,6 +4293,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.46
 
+  '@radix-ui/react-tabs@1.1.2(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@18.2.46)(react@18.2.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.2.46)(react@18.2.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.2.46)(react@18.2.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-roving-focus': 1.1.1(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.46)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.46
+      '@types/react-dom': 18.2.18
+
   '@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.46)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.26.7
@@ -5133,7 +5165,7 @@ snapshots:
       '@typescript-eslint/parser': 8.19.1(eslint@8.57.1)(typescript@5.3.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.3(eslint@8.57.1)
@@ -5157,7 +5189,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -5173,14 +5205,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.19.1(eslint@8.57.1)(typescript@5.3.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5195,7 +5227,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
### TL;DR
Reorganized the admin portal into a tabbed interface with dedicated sections for challenges, teams, and users, while adding cross-navigation between sections.

![CleanShot 2025-02-05 at 17.39.00.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GNKlOysjLXG1QUlNa868/797a9a9a-cc83-4636-86c5-df7777af1e55.gif)

### What changed?
- Split admin interface into three main tabs: Challenges, Teams, and Users
- Added URL state management to persist tab selection and search parameters
- Created new UserManagement component to handle user-related functionality
- Implemented cross-navigation between sections (clicking usernames/team names)
- Added clear buttons (X) to search inputs
- Added new tabs UI component

### How to test?
1. Navigate to the admin portal
2. Verify tab navigation between Challenges, Teams, and Users sections
3. Test search functionality in each section
4. Click on usernames in Teams view to navigate to Users tab
5. Click on team names in Users view to navigate to Teams tab
6. Verify URL parameters update correctly when switching tabs/searching
7. Confirm search state clears when switching tabs

### Why make this change?
Improves the admin portal's organization and usability by separating concerns into distinct sections while maintaining interconnectivity through cross-navigation. This makes the interface more intuitive and easier to manage, especially when dealing with related data across different sections.