### PR TITLE
feat(user.ts): add firstName and lastName columns to the user table to store user's first and last names

### DIFF
--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -11,6 +11,8 @@ export type UserInfo = {
   id: string;
   email: string;
   githubUsername: string;
+  firstName: string | null;
+  lastName: string | null;
   teamId: string | null;
   teamName: string | null;
   teamRole: string | null;
@@ -31,6 +33,8 @@ export async function getAllUsersWithoutPagination(): Promise<UserInfo[]> {
         id: user.id,
         email: user.email,
         githubUsername: user.githubUsername,
+        firstName: user.firstName,
+        lastName: user.lastName,
         role: user.role,
         createdAt: user.createdAt,
         teamId: teamMembers.teamId,
@@ -50,6 +54,8 @@ export async function getAllUsersWithoutPagination(): Promise<UserInfo[]> {
       id: user.id,
       email: user.email,
       githubUsername: user.githubUsername,
+      firstName: user.firstName || null,
+      lastName: user.lastName || null,
       teamId: user.teamId || null,
       teamName: user.teamName || null,
       teamRole: user.teamRole || null,
@@ -85,6 +91,8 @@ export async function getUserById(userId: string): Promise<UserInfo | null> {
         id: user.id,
         githubUsername: user.githubUsername,
         email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
         teamId: team.id,
         teamName: team.name,
         teamRole: teamMembers.role,
@@ -103,6 +111,8 @@ export async function getUserById(userId: string): Promise<UserInfo | null> {
         user.id,
         user.githubUsername,
         user.email,
+        user.firstName,
+        user.lastName,
         team.name,
         teamMembers.role,
         team.id,
@@ -117,6 +127,8 @@ export async function getUserById(userId: string): Promise<UserInfo | null> {
     const foundUser = searchedUser[0];
     return {
       ...foundUser,
+      firstName: foundUser.firstName || null,
+      lastName: foundUser.lastName || null,
       teamId: foundUser.teamId || null,
       teamName: foundUser.teamName || null,
       teamRole: foundUser.teamRole || null,
@@ -143,6 +155,8 @@ export async function getAllUsers(page = 1, pageSize = 10): Promise<PaginatedUse
       id: user.id,
       email: user.email,
       githubUsername: user.githubUsername,
+      firstName: user.firstName,
+      lastName: user.lastName,
       role: user.role,
       createdAt: user.createdAt,
       teamId: teamMembers.teamId,
@@ -165,6 +179,8 @@ export async function getAllUsers(page = 1, pageSize = 10): Promise<PaginatedUse
       id: user.id,
       email: user.email,
       githubUsername: user.githubUsername,
+      firstName: user.firstName || null,
+      lastName: user.lastName || null,
       teamId: user.teamId || null,
       teamName: user.teamName || null,
       teamRole: user.teamRole || null,

--- a/components/custom/admin/AdminClient.tsx
+++ b/components/custom/admin/AdminClient.tsx
@@ -15,8 +15,7 @@ import UserManagement from "./UserManagement";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-
-type SearchType = "username" | "email" | "team";
+import type { SearchType } from "./UserManagement";
 
 export default function AdminClient() {
   const searchParams = useSearchParams();
@@ -56,6 +55,7 @@ export default function AdminClient() {
       params.delete("searchType");
     }
     router.push(`/admin?${params.toString()}`);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery, searchType]);
 
   // Add navigation functions
@@ -185,6 +185,10 @@ export default function AdminClient() {
     }
   };
 
+  const handleSearchTypeChange = (type: SearchType) => {
+    setSearchType(type);
+  };
+
   return (
     <div className="flex flex-col gap-8 p-5 md:p-20">
       <Toaster />
@@ -219,7 +223,7 @@ export default function AdminClient() {
             isSyncing={isSyncing}
             searchType={searchType}
             searchQuery={searchQuery}
-            onSearchTypeChange={setSearchType}
+            onSearchTypeChange={handleSearchTypeChange}
             onSearchQueryChange={setSearchQuery}
             onUploadFile={handleUploadFile}
             onSyncEventbrite={handleSyncEventbrite}
@@ -227,7 +231,6 @@ export default function AdminClient() {
             onRemoveUser={handleRemoveUser}
             onEditUser={handleEditUser}
             onNavigateToTeam={navigateToTeam}
-            onNavigateToUser={navigateToUser}
           />
         </TabsContent>
       </Tabs>

--- a/components/custom/admin/TeamManagement.tsx
+++ b/components/custom/admin/TeamManagement.tsx
@@ -263,12 +263,15 @@ export default function TeamManagement({
                             onClick={() => onNavigateToUser(user.githubUsername)}
                             className="text-blue-600 hover:underline"
                           >
-                            {user.githubUsername}
-                          </button>{" "}
-                          <span
-                            className={`text-neutral-500 ${user.role === "admin" ? "font-medium text-blue-600" : ""}`}
-                          >
-                            ({user.teamRole}){user.role === "admin" && " • Admin"}
+                            {user.firstName && user.lastName
+                              ? `${user.firstName} ${user.lastName} (${user.githubUsername})`
+                              : user.githubUsername}
+                          </button>
+                          {user.role === "admin" && (
+                            <span className="ml-1 text-sm font-medium text-blue-600">• Admin</span>
+                          )}
+                          <span className="ml-1 text-sm text-neutral-500">
+                            • {user.teamRole === "leader" ? "Leader" : "Member"}
                           </span>
                         </li>
                       ))}

--- a/drizzle/0009_add-name-to-user.sql
+++ b/drizzle/0009_add-name-to-user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user" ADD COLUMN "firstName" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "lastName" text;

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,539 @@
+{
+  "id": "f4054406-f9f4-4ba7-b8f0-66ebe3d9c9bc",
+  "prevId": "f8e3b08b-e766-46ef-a5af-0ca807af5d78",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOW()'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOW()'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.main_event_registrations": {
+      "name": "main_event_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_profile_url": {
+          "name": "github_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_profile_url": {
+          "name": "linkedin_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_team": {
+          "name": "has_team",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_email": {
+          "name": "ticket_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "main_event_email_idx": {
+          "name": "main_event_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_name_idx": {
+          "name": "team_name_idx",
+          "columns": [
+            {
+              "expression": "team_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "main_event_registrations_email_unique": {
+          "name": "main_event_registrations_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pre_event_registrations": {
+      "name": "pre_event_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendee_id": {
+          "name": "attendee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cell_phone": {
+          "name": "cell_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_in": {
+          "name": "checked_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_attendee_idx": {
+          "name": "event_attendee_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attendee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'participant'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_githubUsername_unique": {
+          "name": "user_githubUsername_unique",
+          "nullsNotDistinct": false,
+          "columns": ["githubUsername"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "role_verification": {
+          "name": "role_verification",
+          "value": "\"user\".\"role\" IN ('admin', 'participant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "leaderId": {
+          "name": "leaderId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challengeId": {
+          "name": "challengeId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_leaderId_user_id_fk": {
+          "name": "team_leaderId_user_id_fk",
+          "tableFrom": "team",
+          "tableTo": "user",
+          "columnsFrom": ["leaderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_challengeId_challenges_id_fk": {
+          "name": "team_challengeId_challenges_id_fk",
+          "tableFrom": "team",
+          "tableTo": "challenges",
+          "columnsFrom": ["challengeId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_name_unique": {
+          "name": "team_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "teamId": {
+          "name": "teamId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_teamId_team_id_fk": {
+          "name": "team_members_teamId_team_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "team",
+          "columnsFrom": ["teamId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_userId_user_id_fk": {
+          "name": "team_members_userId_user_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_teamId_userId_pk": {
+          "name": "team_members_teamId_userId_pk",
+          "columns": ["teamId", "userId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_member_role": {
+          "name": "check_member_role",
+          "value": "\"team_members\".\"role\" IN ('leader', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1738731358006,
       "tag": "0008_challenges",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1738742449346,
+      "tag": "0009_add-name-to-user",
+      "breakpoints": true
     }
   ]
 }

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -3,6 +3,33 @@ export type Json = string | number | boolean | null | { [key: string]: Json | un
 export type Database = {
   public: {
     Tables: {
+      challenges: {
+        Row: {
+          created_at: string;
+          description: string;
+          id: string;
+          metadata: Json | null;
+          name: string;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          description: string;
+          id?: string;
+          metadata?: Json | null;
+          name: string;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          description?: string;
+          id?: string;
+          metadata?: Json | null;
+          name?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       main_event_registrations: {
         Row: {
           approved_by: string | null;
@@ -98,6 +125,7 @@ export type Database = {
       };
       team: {
         Row: {
+          challengeId: string | null;
           createdAt: string;
           id: string;
           leaderId: string | null;
@@ -105,6 +133,7 @@ export type Database = {
           updatedAt: string;
         };
         Insert: {
+          challengeId?: string | null;
           createdAt?: string;
           id?: string;
           leaderId?: string | null;
@@ -112,6 +141,7 @@ export type Database = {
           updatedAt?: string;
         };
         Update: {
+          challengeId?: string | null;
           createdAt?: string;
           id?: string;
           leaderId?: string | null;
@@ -119,6 +149,13 @@ export type Database = {
           updatedAt?: string;
         };
         Relationships: [
+          {
+            foreignKeyName: "team_challengeId_challenges_id_fk";
+            columns: ["challengeId"];
+            isOneToOne: false;
+            referencedRelation: "challenges";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "team_leaderId_user_id_fk";
             columns: ["leaderId"];
@@ -165,22 +202,28 @@ export type Database = {
         Row: {
           createdAt: string;
           email: string;
+          firstName: string | null;
           githubUsername: string;
           id: string;
+          lastName: string | null;
           role: string | null;
         };
         Insert: {
           createdAt?: string;
           email: string;
+          firstName?: string | null;
           githubUsername: string;
           id?: string;
+          lastName?: string | null;
           role?: string | null;
         };
         Update: {
           createdAt?: string;
           email?: string;
+          firstName?: string | null;
           githubUsername?: string;
           id?: string;
+          lastName?: string | null;
           role?: string | null;
         };
         Relationships: [];

--- a/utils/db/schema/user.ts
+++ b/utils/db/schema/user.ts
@@ -7,6 +7,8 @@ export const user = pgTable(
     id: uuid().defaultRandom().primaryKey(),
     email: text().notNull().unique(),
     githubUsername: text().notNull().unique(),
+    firstName: text(),
+    lastName: text(),
     createdAt: timestamp().notNull().defaultNow(),
     role: text().default("participant"),
   },


### PR DESCRIPTION
### TL;DR

Added first and last name fields to user profiles and updated the UI to display full names when available.

### What changed?

- Added `firstName` and `lastName` fields to the user table
- Updated user management UI to display full names instead of just GitHub usernames
- Enhanced search functionality to include searching by name
- Modified team management display to show full names when available
- Updated user service layer to handle new name fields
- Added name field handling in the Google Sheets import function

### How to test?

1. Run database migrations to add the new name fields
2. Import users via Google Sheets with first and last names
3. Verify names appear in the user management table
4. Test searching users by full name, first name, or last name
5. Check team management view to ensure names display correctly
6. Verify existing functionality still works with users who don't have names set

### Why make this change?

To improve user identification and management by displaying real names instead of just GitHub usernames, making it easier to identify and manage users throughout the application. This also aligns the user data structure with the registration form data, ensuring consistency between imported user information and the application's user model.