### PR TITLE
make nav bar sticky and hide/reveal based on scroll

### DIFF
--- a/components/custom/NavigationBar.tsx
+++ b/components/custom/NavigationBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { RxHamburgerMenu } from "react-icons/rx";
 import { FaXmark } from "react-icons/fa6";
 import Link from "next/link";
@@ -20,60 +20,89 @@ const navigationLinks = [
 
 export default function NavigtionBar() {
   const [expandMobileNav, setExpandMobileNav] = useState(false);
+  const [isVisible, setIsVisible] = useState(true);
+  const [lastScrollY, setLastScrollY] = useState(0);
 
-  // TODO: Add Framer Motion Animate
+  useEffect(() => {
+    const controlNavbar = () => {
+      const currentScrollY = window.scrollY;
+
+      if (currentScrollY < lastScrollY || currentScrollY < 50) {
+        setIsVisible(true);
+      } else if (currentScrollY > lastScrollY && currentScrollY > 50) {
+        setIsVisible(false);
+      }
+
+      setLastScrollY(currentScrollY);
+    };
+
+    window.addEventListener("scroll", controlNavbar);
+
+    return () => {
+      window.removeEventListener("scroll", controlNavbar);
+    };
+  }, [lastScrollY]);
 
   return (
-    <div className={`relative w-screen`}>
-      <div className="m-2 bg-hackomania-red p-5 md:mx-20 md:my-10">
-        <nav className="hidden flex-row justify-end gap-3 text-white md:flex" id="full-nav">
-          {navigationLinks.map((link) => (
-            <motion.div key={link.title} whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
-              <Link href={link.href} className="text-white hover:underline">
-                {link.title}
-              </Link>
-            </motion.div>
-          ))}
-        </nav>
+    <>
+      <motion.div
+        className={`fixed top-0 z-50 w-screen`}
+        initial={{ y: 0 }}
+        animate={{ y: isVisible ? 0 : -100 }}
+        transition={{ duration: 0.3 }}
+      >
+        <div className="m-2 bg-hackomania-red p-5 md:mx-20 md:my-10">
+          <nav className="hidden flex-row justify-end gap-3 text-white md:flex" id="full-nav">
+            {navigationLinks.map((link) => (
+              <motion.div key={link.title} whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
+                <Link href={link.href} className="text-white hover:underline">
+                  {link.title}
+                </Link>
+              </motion.div>
+            ))}
+          </nav>
 
-        {expandMobileNav ? (
-          <FaXmark
-            className="ml-auto block text-2xl text-white md:hidden"
-            onClick={() => setExpandMobileNav(false)}
-          />
-        ) : (
-          <RxHamburgerMenu
-            className="ml-auto block text-2xl text-white md:hidden"
-            onClick={() => setExpandMobileNav(true)}
-          />
-        )}
-
-        <AnimatePresence>
-          {expandMobileNav && (
-            <motion.nav
-              className="flex flex-col gap-3"
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: "auto" }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.2 }}
-            >
-              {navigationLinks.map((link) => (
-                <motion.div
-                  key={link.title}
-                  initial={{ x: -20, opacity: 0 }}
-                  animate={{ x: 0, opacity: 1 }}
-                  exit={{ x: -20, opacity: 0 }}
-                >
-                  <Link href={link.href} className="text-white">
-                    {link.title}
-                  </Link>
-                </motion.div>
-              ))}
-            </motion.nav>
+          {expandMobileNav ? (
+            <FaXmark
+              className="ml-auto block text-2xl text-white md:hidden"
+              onClick={() => setExpandMobileNav(false)}
+            />
+          ) : (
+            <RxHamburgerMenu
+              className="ml-auto block text-2xl text-white md:hidden"
+              onClick={() => setExpandMobileNav(true)}
+            />
           )}
-        </AnimatePresence>
-      </div>
-      <div className={`grid-bg pointer-events-none absolute h-96 w-full md:h-60`}></div>
-    </div>
+
+          <AnimatePresence>
+            {expandMobileNav && (
+              <motion.nav
+                className="flex flex-col gap-3"
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: "auto" }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ duration: 0.2 }}
+              >
+                {navigationLinks.map((link) => (
+                  <motion.div
+                    key={link.title}
+                    initial={{ x: -20, opacity: 0 }}
+                    animate={{ x: 0, opacity: 1 }}
+                    exit={{ x: -20, opacity: 0 }}
+                  >
+                    <Link href={link.href} className="text-white">
+                      {link.title}
+                    </Link>
+                  </motion.div>
+                ))}
+              </motion.nav>
+            )}
+          </AnimatePresence>
+        </div>
+        <div className={`grid-bg pointer-events-none absolute h-96 w-full md:h-60`}></div>
+      </motion.div>
+      {/* Spacer div to prevent content from being hidden under fixed navbar */}
+      <div className="h-[120px] md:h-[180px]"></div>
+    </>
   );
 }


### PR DESCRIPTION
### TL;DR
Added hide-on-scroll behavior to the navigation bar

### What changed?
- Made the navigation bar fixed to the top of the screen
- Added scroll detection to hide/show the navigation bar based on scroll direction
- Added a spacer div to prevent content from being hidden under the fixed navbar
- Implemented smooth animation transitions for the hide/show behavior

### How to test?
1. Load any page with the navigation bar
2. Scroll down to verify the navbar hides
3. Scroll up to verify the navbar reappears
4. Verify content doesn't jump when the navbar hides/shows
5. Check that the navbar remains visible when near the top of the page

### Why make this change?
Improves user experience by maximizing screen real estate while scrolling through content, while keeping navigation easily accessible when needed. This pattern is commonly used in modern web applications to balance navigation accessibility with content visibility.