### PR TITLE
feat(team.ts): add 'submission' column to the 'team' table to store project submission details feat(user/home/page.tsx): add project submission ui

### DIFF
--- a/app/api/teams/[teamId]/submission/route.ts
+++ b/app/api/teams/[teamId]/submission/route.ts
@@ -1,0 +1,67 @@
+"use server";
+
+import { getTeamById, updateTeam } from "@/app/services/team";
+import { getUserFromSession } from "@/app/services/auth";
+import { NextRequest, NextResponse } from "next/server";
+import { TeamSubmission } from "@/utils/db/schema/team";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ teamId: string }> },
+) {
+  try {
+    const user = await getUserFromSession();
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        {
+          status: 401,
+        },
+      );
+    }
+
+    const { teamId } = await params;
+    const team = await getTeamById(teamId);
+    if (!team) {
+      return NextResponse.json(
+        { error: "Team not found" },
+        {
+          status: 404,
+        },
+      );
+    }
+
+    // Check if user is part of the team
+    const isTeamMember = team.users.some((member) => member.id === user.id);
+    if (!isTeamMember) {
+      return NextResponse.json(
+        { error: "You are not authorized to submit for this team" },
+        { status: 403 },
+      );
+    }
+
+    // Check if team has a challenge
+    if (!team.challengeId) {
+      return NextResponse.json(
+        { error: "Team does not have a challenge selected" },
+        { status: 400 },
+      );
+    }
+
+    const submission: TeamSubmission = await request.json();
+
+    // Update team with submission
+    await updateTeam(team.id, {
+      submission,
+    });
+
+    return NextResponse.json({
+      message: "Submission updated successfully",
+    });
+  } catch (error) {
+    console.error("Error updating team submission:", error);
+    return NextResponse.json({ error: "Failed to update team submission" }, {
+      status: 500,
+    });
+  }
+}

--- a/app/services/auth.ts
+++ b/app/services/auth.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import { getUserById } from "@/app/services/user";
+import { getUser } from "@/utils/supabase/user";
+import { User } from "@supabase/supabase-js";
+
+export async function getUserFromSession() {
+  try {
+    const supabaseUser = (await getUser()) as User;
+    if (!supabaseUser) {
+      return null;
+    }
+
+    const user = await getUserById(supabaseUser.id);
+    return user;
+  } catch (error) {
+    console.error("Error getting user from session:", error);
+    return null;
+  }
+}

--- a/app/services/team.ts
+++ b/app/services/team.ts
@@ -40,3 +40,21 @@ export async function getTeamById(teamId: string): Promise<Team | null> {
     return null;
   }
 }
+
+export async function updateTeam(teamId: string, data: Partial<Team>) {
+  try {
+    const [updatedTeam] = await db
+      .update(team)
+      .set({
+        ...data,
+        updatedAt: new Date(),
+      })
+      .where(eq(team.id, teamId))
+      .returning();
+
+    return updatedTeam;
+  } catch (error) {
+    console.error("Error updating team:", error);
+    throw error;
+  }
+}

--- a/app/user/home/page.tsx
+++ b/app/user/home/page.tsx
@@ -4,8 +4,9 @@ import { getUserById, UserInfo } from "@/app/services/user";
 import EventbriteCheckoutWidgetButton from "@/components/custom/EventbriteCheckoutWidgetButton";
 import SignOutButton from "@/components/custom/SignOutButton";
 import SuspenseLoadingSpinner from "@/components/custom/SuspenseLoadingSpinner";
-import EditTeamButtons from "@/components/custom/user-team/EditTeamButtons";
+import ChallengeSelection from "@/components/custom/user-team/ChallengeSelection";
 import TeamManagementSection from "@/components/custom/user-team/TeamManagementSection";
+import TeamSubmissionForm from "@/components/custom/user-team/TeamSubmissionForm";
 import { getUser } from "@/utils/supabase/user";
 import { User } from "@supabase/supabase-js";
 import { Suspense } from "react";
@@ -58,31 +59,51 @@ interface UserInfoSectionProps {
 
 function UserInfoSection({ user }: UserInfoSectionProps) {
   return (
-    <section className="p-5">
-      <h2 className="mb-3 text-2xl font-semibold">Your Information</h2>
+    <section className="p-8">
+      <h2 className="mb-3 text-2xl font-semibold">Eventbrite</h2>
       <EventRegistrationStatus user={user} />
     </section>
   );
 }
 
-interface TeamInfoSectionProps {
+interface ChallengeAndTeamInfoSectionsProps {
   user: UserInfo;
   userTeam: Team | null;
 }
 
-function TeamInfoSection({ user, userTeam }: TeamInfoSectionProps) {
+function ChallengeAndTeamInfoSections({ user, userTeam }: ChallengeAndTeamInfoSectionsProps) {
   return (
-    <section className="p-5" id="team-management">
+    <div className="p-8">
       {userTeam && (
-        <div className="flex flex-col gap-3 md:flex-row md:items-center">
-          <h2 className="text-2xl font-semibold">
-            Your Team {user.teamName && <span className="font-normal">: {user.teamName}</span>}
-          </h2>
-          {userTeam.leaderId === user.id && <EditTeamButtons teamID={userTeam.id} />}
-        </div>
+        <>
+          <div className="space-y-8">
+            {/* Challenge Selection Section */}
+            <div>
+              <ChallengeSelection teamId={userTeam.id} currentChallengeId={userTeam.challengeId} />
+            </div>
+
+            {/* Project Submission Section - Only visible if team has a challenge */}
+            {userTeam.challengeId && (
+              <div>
+                <div className="-mx-8 my-3 border border-neutral-400"></div>
+                <h3 className="mb-4 text-xl font-semibold">Project Submission</h3>
+                <TeamSubmissionForm
+                  teamId={userTeam.id}
+                  initialSubmission={userTeam.submission ?? undefined}
+                />
+              </div>
+            )}
+
+            {/* Team Details Section */}
+            <div className="-mx-8 my-3 border border-neutral-400"></div>
+            <div>
+              <h3 className="mb-4 text-xl font-semibold">Team Details</h3>
+              <TeamManagementSection user={user} userTeam={userTeam} />
+            </div>
+          </div>
+        </>
       )}
-      <TeamManagementSection user={user} userTeam={userTeam} />
-    </section>
+    </div>
   );
 }
 
@@ -129,7 +150,7 @@ export default async function UserHome() {
         <div className="my-3 border border-neutral-400"></div>
 
         <Suspense key={teamKey} fallback={<SuspenseLoadingSpinner />}>
-          {<TeamInfoSection key={teamKey} user={user} userTeam={userTeam} />}
+          {<ChallengeAndTeamInfoSections key={teamKey} user={user} userTeam={userTeam} />}
         </Suspense>
       </div>
     </div>

--- a/components/custom/admin/ExportTeamsAsExcelButton.tsx
+++ b/components/custom/admin/ExportTeamsAsExcelButton.tsx
@@ -32,6 +32,9 @@ export function ExportTeamsAsExcelButton({ teams }: ExportTeamsAsExcelButtonProp
         "All Members Registered": team.users.every((user) => user.mainEventRegistered)
           ? "Yes"
           : "No",
+        "Project Description": team.submission?.projectDescription || "",
+        "Slides URL": team.submission?.slidesUrl || "",
+        "Repository URL": team.submission?.repoUrl || "",
       }));
 
       // Create worksheet
@@ -49,6 +52,9 @@ export function ExportTeamsAsExcelButton({ teams }: ExportTeamsAsExcelButtonProp
         { wch: 25 }, // Challenge
         { wch: 100 }, // Members
         { wch: 15 }, // All Members Registered
+        { wch: 100 }, // Project Description
+        { wch: 50 }, // Slides URL
+        { wch: 50 }, // Repository URL
       ];
       ws["!cols"] = colWidths;
 

--- a/components/custom/admin/TeamManagement.tsx
+++ b/components/custom/admin/TeamManagement.tsx
@@ -55,6 +55,7 @@ export default function TeamManagement({
   const [teamFilter, setTeamFilter] = useState<TeamFilter>("all");
   const [selectedChallengeId, setSelectedChallengeId] = useState<string>("all");
   const [hideUnregisteredTeams, setHideUnregisteredTeams] = useState(true);
+  const [showSubmittedTeamsOnly, setShowSubmittedTeamsOnly] = useState(false);
 
   // Use external search query if provided, otherwise use internal state
   const searchQuery = externalSearchQuery ?? internalSearchQuery;
@@ -175,9 +176,21 @@ export default function TeamManagement({
         return false;
       }
 
+      // Apply submission filter
+      if (showSubmittedTeamsOnly && !team.submission) {
+        return false;
+      }
+
       return true;
     });
-  }, [teams, searchQuery, teamFilter, selectedChallengeId, hideUnregisteredTeams]);
+  }, [
+    teams,
+    searchQuery,
+    teamFilter,
+    selectedChallengeId,
+    hideUnregisteredTeams,
+    showSubmittedTeamsOnly,
+  ]);
 
   return (
     <div className="rounded-lg border border-neutral-400 p-4">
@@ -244,18 +257,34 @@ export default function TeamManagement({
             </Select>
           </div>
 
-          <div className="flex items-center gap-2">
-            <Checkbox
-              id="hideUnregisteredTeams"
-              checked={hideUnregisteredTeams}
-              onCheckedChange={(checked) => setHideUnregisteredTeams(checked as boolean)}
-            />
-            <label
-              htmlFor="hideUnregisteredTeams"
-              className="text-sm text-neutral-500 hover:text-neutral-700"
-            >
-              Hide teams with unregistered members
-            </label>
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="hideUnregisteredTeams"
+                checked={hideUnregisteredTeams}
+                onCheckedChange={(checked) => setHideUnregisteredTeams(checked as boolean)}
+              />
+              <label
+                htmlFor="hideUnregisteredTeams"
+                className="text-sm text-neutral-500 hover:text-neutral-700"
+              >
+                Hide teams with unregistered members
+              </label>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="showSubmittedTeamsOnly"
+                checked={showSubmittedTeamsOnly}
+                onCheckedChange={(checked) => setShowSubmittedTeamsOnly(checked as boolean)}
+              />
+              <label
+                htmlFor="showSubmittedTeamsOnly"
+                className="text-sm text-neutral-500 hover:text-neutral-700"
+              >
+                Show only teams with project submissions
+              </label>
+            </div>
           </div>
         </div>
       </div>

--- a/components/custom/admin/TeamManagement.tsx
+++ b/components/custom/admin/TeamManagement.tsx
@@ -269,6 +269,7 @@ export default function TeamManagement({
               <TableHead>Team Name</TableHead>
               <TableHead>Members</TableHead>
               <TableHead>Current Challenge</TableHead>
+              <TableHead>Submission Status</TableHead>
               <TableHead>Actions</TableHead>
             </TableRow>
           </TableHeader>
@@ -324,6 +325,41 @@ export default function TeamManagement({
                         ))}
                       </SelectContent>
                     </Select>
+                  </TableCell>
+                  <TableCell>
+                    {team.challengeId ? (
+                      team.submission ? (
+                        <div className="text-sm">
+                          <p className="text-green-600">✓ Submitted</p>
+                          <div className="mt-1 space-y-1">
+                            {team.submission.repoUrl && (
+                              <a
+                                href={team.submission.repoUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="block text-blue-600 hover:underline"
+                              >
+                                View Repository
+                              </a>
+                            )}
+                            {team.submission.slidesUrl && (
+                              <a
+                                href={team.submission.slidesUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="block text-blue-600 hover:underline"
+                              >
+                                View Slides
+                              </a>
+                            )}
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="text-sm text-yellow-600">Not submitted yet</p>
+                      )
+                    ) : (
+                      <p className="text-sm text-neutral-500">No challenge selected</p>
+                    )}
                   </TableCell>
                   <TableCell>
                     <Dialog>

--- a/components/custom/user-team/ChallengeSelection.tsx
+++ b/components/custom/user-team/ChallengeSelection.tsx
@@ -88,7 +88,7 @@ export default function ChallengeSelection({
   return (
     <div className="space-y-4">
       <div>
-        <h3 className="text-lg font-medium">Challenge Selection</h3>
+        <h2 className="text-xl font-medium">Challenge Selection</h2>
         <p className="text-sm text-neutral-500">
           Select a challenge for your team to participate in.
         </p>

--- a/components/custom/user-team/TeamManagementSection.tsx
+++ b/components/custom/user-team/TeamManagementSection.tsx
@@ -1,13 +1,14 @@
-import { UserInfo } from "@/app/services/user";
-import AddMembers from "./AddMembers";
-import NoTeamManagement from "./NoTeamManagement";
-import TeamManagement from "./TeamManagement";
 import { Team } from "@/app/services/team";
+import { UserInfo } from "@/app/services/user";
 import { Suspense } from "react";
 import SuspenseLoadingSpinner from "../SuspenseLoadingSpinner";
-import ChallengeSelection from "./ChallengeSelection";
+import AddMembers from "./AddMembers";
+import EditTeamButtons from "./EditTeamButtons";
+import NoTeamManagement from "./NoTeamManagement";
+import TeamManagement from "./TeamManagement";
 
 export default async function TeamManagementSection({
+  user,
   userTeam,
 }: {
   user: UserInfo;
@@ -21,6 +22,7 @@ export default async function TeamManagementSection({
   return userTeam ? (
     <div id="team-details" className="flex flex-col justify-center gap-2">
       <div>
+        {userTeam.leaderId === user.id && <EditTeamButtons teamID={userTeam.id} />}
         <p className="text-neutral-500">
           <span className="font-medium">Team ID: </span>
           {userTeam.id}
@@ -40,12 +42,6 @@ export default async function TeamManagementSection({
       <div className="mt-2">
         <Suspense key={`members-${teamKey}`} fallback={<SuspenseLoadingSpinner />}>
           <AddMembers teamId={userTeam.id} numMembers={userTeam.users.length} />
-        </Suspense>
-      </div>
-
-      <div className="mt-4">
-        <Suspense key={`challenge-${teamKey}`} fallback={<SuspenseLoadingSpinner />}>
-          <ChallengeSelection teamId={userTeam.id} currentChallengeId={userTeam.challengeId} />
         </Suspense>
       </div>
     </div>

--- a/components/custom/user-team/TeamSubmissionForm.tsx
+++ b/components/custom/user-team/TeamSubmissionForm.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { TeamSubmission } from "@/utils/db/schema/team";
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface TeamSubmissionFormProps {
+  teamId: string;
+  initialSubmission?: TeamSubmission;
+}
+
+export default function TeamSubmissionForm({ teamId, initialSubmission }: TeamSubmissionFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submission, setSubmission] = useState<TeamSubmission>(
+    initialSubmission || {
+      projectDescription: "",
+      slidesUrl: "",
+      repoUrl: "",
+    },
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch(`/api/teams/${teamId}/submission`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(submission),
+      });
+
+      if (!response.ok) throw new Error("Failed to submit project");
+
+      toast.success("Project submitted successfully!");
+    } catch (error) {
+      console.error("Error submitting project:", error);
+      toast.error("Failed to submit project");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="projectDescription">Project Description</Label>
+        <Textarea
+          id="projectDescription"
+          placeholder="Describe your project..."
+          value={submission.projectDescription}
+          onChange={(e) =>
+            setSubmission((prev) => ({ ...prev, projectDescription: e.target.value }))
+          }
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="slidesUrl">Slides URL</Label>
+        <Input
+          id="slidesUrl"
+          type="url"
+          placeholder="https://..."
+          value={submission.slidesUrl}
+          onChange={(e) => setSubmission((prev) => ({ ...prev, slidesUrl: e.target.value }))}
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="repoUrl">Repository URL</Label>
+        <Input
+          id="repoUrl"
+          type="url"
+          placeholder="https://github.com/..."
+          value={submission.repoUrl}
+          onChange={(e) => setSubmission((prev) => ({ ...prev, repoUrl: e.target.value }))}
+          required
+        />
+      </div>
+
+      <Button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? (
+          <>
+            <span className="loading loading-spinner" />
+            {initialSubmission ? "Re-submitting..." : "Submitting..."}
+          </>
+        ) : initialSubmission ? (
+          "Re-submit"
+        ) : (
+          "Submit"
+        )}
+      </Button>
+    </form>
+  );
+}

--- a/drizzle/0010_team-submission.sql
+++ b/drizzle/0010_team-submission.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "team" ADD COLUMN "submission" json;

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,545 @@
+{
+  "id": "a78544fb-038e-4482-894a-d78ae555d1fc",
+  "prevId": "f4054406-f9f4-4ba7-b8f0-66ebe3d9c9bc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOW()'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOW()'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.main_event_registrations": {
+      "name": "main_event_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_profile_url": {
+          "name": "github_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_profile_url": {
+          "name": "linkedin_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_team": {
+          "name": "has_team",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_email": {
+          "name": "ticket_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "main_event_email_idx": {
+          "name": "main_event_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_name_idx": {
+          "name": "team_name_idx",
+          "columns": [
+            {
+              "expression": "team_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "main_event_registrations_email_unique": {
+          "name": "main_event_registrations_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pre_event_registrations": {
+      "name": "pre_event_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendee_id": {
+          "name": "attendee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cell_phone": {
+          "name": "cell_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_in": {
+          "name": "checked_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_attendee_idx": {
+          "name": "event_attendee_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attendee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'participant'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_githubUsername_unique": {
+          "name": "user_githubUsername_unique",
+          "nullsNotDistinct": false,
+          "columns": ["githubUsername"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "role_verification": {
+          "name": "role_verification",
+          "value": "\"user\".\"role\" IN ('admin', 'participant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "leaderId": {
+          "name": "leaderId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challengeId": {
+          "name": "challengeId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission": {
+          "name": "submission",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_leaderId_user_id_fk": {
+          "name": "team_leaderId_user_id_fk",
+          "tableFrom": "team",
+          "tableTo": "user",
+          "columnsFrom": ["leaderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_challengeId_challenges_id_fk": {
+          "name": "team_challengeId_challenges_id_fk",
+          "tableFrom": "team",
+          "tableTo": "challenges",
+          "columnsFrom": ["challengeId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_name_unique": {
+          "name": "team_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "teamId": {
+          "name": "teamId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_teamId_team_id_fk": {
+          "name": "team_members_teamId_team_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "team",
+          "columnsFrom": ["teamId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_userId_user_id_fk": {
+          "name": "team_members_userId_user_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_teamId_userId_pk": {
+          "name": "team_members_teamId_userId_pk",
+          "columns": ["teamId", "userId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_member_role": {
+          "name": "check_member_role",
+          "value": "\"team_members\".\"role\" IN ('leader', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1738742449346,
       "tag": "0009_add-name-to-user",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1738908829661,
+      "tag": "0010_team-submission",
+      "breakpoints": true
     }
   ]
 }

--- a/utils/db/schema/team.ts
+++ b/utils/db/schema/team.ts
@@ -1,9 +1,15 @@
 import { pgTable } from "drizzle-orm/pg-core";
-import { check, primaryKey, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { check, json, primaryKey, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { user } from "./user";
 import { sql } from "drizzle-orm";
 import { relations } from "drizzle-orm";
 import { challenges } from "./challenge";
+
+export type TeamSubmission = {
+  projectDescription?: string;
+  slidesUrl?: string;
+  repoUrl?: string;
+};
 
 export const team = pgTable("team", {
   id: uuid().defaultRandom().primaryKey(),
@@ -12,6 +18,7 @@ export const team = pgTable("team", {
   updatedAt: timestamp().notNull().defaultNow(),
   leaderId: uuid().references(() => user.id),
   challengeId: uuid().references(() => challenges.id),
+  submission: json("submission").$type<TeamSubmission>(),
 });
 
 export const teamMembers = pgTable(


### PR DESCRIPTION
feat(team.ts): add 'submission' column to the 'team' table to store project submission details
feat(user/home/page.tsx): add project submission ui

feat(TeamManagement.tsx): add support for filtering teams based on project submission status

- Add `showSubmittedTeamsOnly` state variable to manage whether to show only teams with project submissions
- Update the filter function to consider the `showSubmittedTeamsOnly` state variable when filtering teams
- Add checkbox input and label to toggle the `showSubmittedTeamsOnly` state variable in the UI