### PR TITLE
fix users without teams not added into the users table

### DIFF
--- a/supabase/functions/prepopulate-google-sheets-main-event-registrations/index.ts
+++ b/supabase/functions/prepopulate-google-sheets-main-event-registrations/index.ts
@@ -332,6 +332,10 @@ serve(async (req) => {
     // Bulk create registrations
     stats.registrations = await createMainEventRegistrations(supabaseClient, approvedRows);
 
+    // Process all approved users first
+    const users = await createOrGetUsers(supabaseClient, approvedRows);
+    stats.users = users.length;
+
     // Get rows with teams
     const rowsWithTeams = approvedRows.filter(
       (row) =>
@@ -340,10 +344,6 @@ serve(async (req) => {
     );
 
     if (rowsWithTeams.length > 0) {
-      // Bulk create/get users
-      const users = await createOrGetUsers(supabaseClient, rowsWithTeams);
-      stats.users = users.length;
-
       // Bulk create/get teams
       const teams = await createOrGetTeams(supabaseClient, rowsWithTeams);
       stats.teams = teams.length;


### PR DESCRIPTION
### TL;DR
Modified the user creation process to handle all approved registrations, not just those with teams.

### What changed?
Moved the `createOrGetUsers` function call outside the team-specific conditional block, ensuring all approved registrants are processed regardless of team affiliation. Previously, users were only created for registrations that included team information.

### How to test?
1. Run the prepopulate Google Sheets function with a mix of registrations (with and without teams)
2. Verify that users are created for all approved registrations
3. Confirm team associations are still properly created for registrations that include team information

### Why make this change?
To ensure all approved registrants have user accounts created in the system, regardless of whether they're part of a team. This fixes a bug where users without team affiliations weren't being properly processed in the system.