### PR TITLE
hide users with teams checkbox

### DIFF
--- a/components/custom/admin/ExportUsersAsExcelButton.tsx
+++ b/components/custom/admin/ExportUsersAsExcelButton.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Download } from "lucide-react";
+import { toast } from "sonner";
+import * as XLSX from "xlsx";
+import { UserInfo } from "@/app/services/user";
+
+interface ExportUsersAsExcelButtonProps {
+  users: UserInfo[];
+}
+
+export function ExportUsersAsExcelButton({ users }: ExportUsersAsExcelButtonProps) {
+  const handleExportToExcel = () => {
+    try {
+      // Prepare data for export
+      const exportData = users.map((user) => ({
+        "Full Name":
+          user.firstName && user.lastName ? `${user.firstName} ${user.lastName}` : "Not provided",
+        "GitHub Username": user.githubUsername,
+        Email: user.email,
+        Team: user.teamName || "No team",
+        "Team Role": user.teamRole || "N/A",
+        "Pre-event Registration": user.preEventRegistered ? "Yes" : "No",
+        "Main Event Registration": user.mainEventRegistered ? "Yes" : "No",
+      }));
+
+      // Create worksheet
+      const ws = XLSX.utils.json_to_sheet(exportData);
+
+      // Add autofilter
+      ws["!autofilter"] = {
+        ref: ws["!ref"] || "A1",
+      };
+
+      // Set column widths
+      const colWidths = [
+        { wch: 30 }, // Full Name
+        { wch: 20 }, // GitHub Username
+        { wch: 30 }, // Email
+        { wch: 30 }, // Team
+        { wch: 15 }, // Team Role
+        { wch: 15 }, // Pre-event Registration
+        { wch: 15 }, // Main Event Registration
+      ];
+      ws["!cols"] = colWidths;
+
+      // Create workbook and append worksheet
+      const wb = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(wb, ws, "Users");
+
+      // Generate filename with current date
+      const date = new Date().toISOString().split("T")[0];
+      const filename = `users_export_${date}.xlsx`;
+
+      // Save file
+      XLSX.writeFile(wb, filename);
+      toast.success("Users exported successfully!");
+    } catch (error) {
+      console.error("Error exporting users:", error);
+      toast.error("Failed to export users");
+    }
+  };
+
+  return (
+    <Button
+      onClick={handleExportToExcel}
+      variant="outline"
+      size="sm"
+      className="flex items-center gap-2"
+    >
+      <Download className="h-4 w-4" />
+      Export to Excel
+    </Button>
+  );
+}

--- a/components/custom/admin/UserManagement.tsx
+++ b/components/custom/admin/UserManagement.tsx
@@ -30,6 +30,7 @@ import {
 import { Check, ChevronsUpDown, Search, Loader2, X } from "lucide-react";
 import { UserActions } from "./UserActions";
 import { Checkbox } from "@/components/ui/checkbox";
+import { ExportUsersAsExcelButton } from "./ExportUsersAsExcelButton";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -178,14 +179,20 @@ export default function UserManagement({
   const [currentPage, setCurrentPage] = useState(1);
   const [searchOpen, setSearchOpen] = useState(false);
   const [hideUnregisteredUsers, setHideUnregisteredUsers] = useState(true);
+  const [hideUsersWithTeams, setHideUsersWithTeams] = useState(false);
 
   // Filter users based on search
   const filteredUsers = useMemo(() => {
-    if (!searchQuery && !hideUnregisteredUsers) return users;
+    if (!searchQuery && !hideUnregisteredUsers && !hideUsersWithTeams) return users;
 
     return users.filter((user) => {
       // Apply main event registration filter
       if (hideUnregisteredUsers && !user.mainEventRegistered) {
+        return false;
+      }
+
+      // Apply team filter
+      if (hideUsersWithTeams && user.teamName) {
         return false;
       }
 
@@ -212,7 +219,7 @@ export default function UserManagement({
           return true;
       }
     });
-  }, [users, searchQuery, searchType, hideUnregisteredUsers]);
+  }, [users, searchQuery, searchType, hideUnregisteredUsers, hideUsersWithTeams]);
 
   const totalPages = Math.ceil(filteredUsers.length / ITEMS_PER_PAGE);
   const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
@@ -236,12 +243,15 @@ export default function UserManagement({
   return (
     <div className="rounded-lg border border-neutral-400 p-4">
       <div className="mb-4">
-        <h2 className="mb-4 text-xl font-semibold">
-          Users{" "}
-          {filteredUsers.length > 0 && (
-            <span className="text-sm text-neutral-500">({filteredUsers.length})</span>
-          )}
-        </h2>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-semibold">
+            Users{" "}
+            {filteredUsers.length > 0 && (
+              <span className="text-sm text-neutral-500">({filteredUsers.length})</span>
+            )}
+          </h2>
+          <ExportUsersAsExcelButton users={filteredUsers} />
+        </div>
 
         <div className="mb-6 space-y-4">
           <form
@@ -455,18 +465,33 @@ export default function UserManagement({
               </Popover>
             </div>
 
-            <div className="flex items-center gap-2">
-              <Checkbox
-                id="hideUnregisteredUsers"
-                checked={hideUnregisteredUsers}
-                onCheckedChange={(checked) => setHideUnregisteredUsers(checked as boolean)}
-              />
-              <label
-                htmlFor="hideUnregisteredUsers"
-                className="text-sm text-neutral-500 hover:text-neutral-700"
-              >
-                Hide users not registered for main event
-              </label>
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="hideUnregisteredUsers"
+                  checked={hideUnregisteredUsers}
+                  onCheckedChange={(checked) => setHideUnregisteredUsers(checked as boolean)}
+                />
+                <label
+                  htmlFor="hideUnregisteredUsers"
+                  className="text-sm text-neutral-500 hover:text-neutral-700"
+                >
+                  Hide users not registered for main event
+                </label>
+              </div>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="hideUsersWithTeams"
+                  checked={hideUsersWithTeams}
+                  onCheckedChange={(checked) => setHideUsersWithTeams(checked as boolean)}
+                />
+                <label
+                  htmlFor="hideUsersWithTeams"
+                  className="text-sm text-neutral-500 hover:text-neutral-700"
+                >
+                  Hide users with teams
+                </label>
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
### TL;DR
Added Excel export functionality and enhanced user filtering options in the admin panel.

### What changed?
- Created a new `ExportUsersAsExcelButton` component that exports user data to Excel with formatted columns
- Added a new filter option to hide users who already have teams
- Integrated the export button in the user management interface
- Excel export includes user details such as name, GitHub username, email, team info, and registration status

### How to test?
1. Navigate to the admin user management panel
2. Try the new "Hide users with teams" filter checkbox
3. Click the "Export to Excel" button
4. Verify the downloaded Excel file contains:
   - Properly formatted columns
   - Correct user information
   - Auto-filter functionality
   - Current date in the filename

### Why make this change?
To improve admin workflow by:
- Enabling easy data export for offline analysis
- Providing better filtering capabilities to identify users without teams
- Streamlining user management for event organization