### PR TITLE
fix admin dropdown challenge select display

### DIFF
--- a/components/custom/admin/TeamManagement.tsx
+++ b/components/custom/admin/TeamManagement.tsx
@@ -387,8 +387,13 @@ export default function TeamManagement({
                         handleAssignChallenge(team.id, value === "none" ? null : value)
                       }
                     >
-                      <SelectTrigger className="w-[200px]">
-                        <SelectValue placeholder="Select a challenge" />
+                      <SelectTrigger className="w-[250px] truncate">
+                        <SelectValue>
+                          {team.challengeId
+                            ? challenges.find((c) => c.id === team.challengeId)?.name ||
+                              "No Challenge"
+                            : "No Challenge"}
+                        </SelectValue>
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="none">No Challenge</SelectItem>

--- a/components/custom/admin/TeamManagement.tsx
+++ b/components/custom/admin/TeamManagement.tsx
@@ -160,44 +160,46 @@ export default function TeamManagement({
 
   // Filter and search teams
   const filteredTeams = useMemo(() => {
-    return teams.filter((team) => {
-      // Apply search filter
-      const matchesSearch = team.name.toLowerCase().includes(searchQuery.toLowerCase());
-      if (!matchesSearch) return false;
+    return teams
+      .filter((team) => {
+        // Apply search filter
+        const matchesSearch = team.name.toLowerCase().includes(searchQuery.toLowerCase());
+        if (!matchesSearch) return false;
 
-      // Apply team size filter
-      const matchesTeamSize = (() => {
-        switch (teamFilter) {
-          case "full":
-            return team.users.length >= MAX_TEAM_SIZE;
-          case "not-full":
-            return team.users.length < MAX_TEAM_SIZE;
-          default:
-            return true;
+        // Apply team size filter
+        const matchesTeamSize = (() => {
+          switch (teamFilter) {
+            case "full":
+              return team.users.length >= MAX_TEAM_SIZE;
+            case "not-full":
+              return team.users.length < MAX_TEAM_SIZE;
+            default:
+              return true;
+          }
+        })();
+        if (!matchesTeamSize) return false;
+
+        // Apply challenge filter
+        const matchesChallenge =
+          selectedChallengeId === "all" ||
+          (selectedChallengeId === "none"
+            ? !team.challengeId
+            : team.challengeId === selectedChallengeId);
+        if (!matchesChallenge) return false;
+
+        // Apply main event registration filter
+        if (hideUnregisteredTeams && team.users.some((user) => !user.mainEventRegistered)) {
+          return false;
         }
-      })();
-      if (!matchesTeamSize) return false;
 
-      // Apply challenge filter
-      const matchesChallenge =
-        selectedChallengeId === "all" ||
-        (selectedChallengeId === "none"
-          ? !team.challengeId
-          : team.challengeId === selectedChallengeId);
-      if (!matchesChallenge) return false;
+        // Apply submission filter
+        if (showSubmittedTeamsOnly && !team.submission) {
+          return false;
+        }
 
-      // Apply main event registration filter
-      if (hideUnregisteredTeams && team.users.some((user) => !user.mainEventRegistered)) {
-        return false;
-      }
-
-      // Apply submission filter
-      if (showSubmittedTeamsOnly && !team.submission) {
-        return false;
-      }
-
-      return true;
-    });
+        return true;
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
   }, [
     teams,
     searchQuery,


### PR DESCRIPTION
Teams are now sorted alphabetically by name in the admin portal

The challenge select dropdown now:
- Shows the currently selected challenge name
- Displays "No Challenge" when no challenge is assigned
- Has an increased width of 250px for better readability
- Properly truncates long challenge names