### PR TITLE
Fix rows from eventbrite cannot be imported

### DIFF
--- a/app/api/admin/teams/route.ts
+++ b/app/api/admin/teams/route.ts
@@ -17,12 +17,16 @@ export async function GET() {
       },
     });
 
-    // Get all registered emails in one query
-    const registeredEmails = await db
-      .select({ email: sql<string>`email` })
+    // Get all registered github usernames in one query
+    const registeredGithubUsernames = await db
+      .select({
+        githubUsername: sql<string>`SUBSTRING(github_profile_url FROM 'github.com/([^/]+)')`,
+      })
       .from(sql`main_event_registrations`);
 
-    const registeredEmailSet = new Set(registeredEmails.map((r) => r.email));
+    const registeredGithubUsernameSet = new Set(
+      registeredGithubUsernames.map((r) => r.githubUsername),
+    );
 
     // Transform the response to match the expected format
     const transformedTeams = teams.map((team) => ({
@@ -30,7 +34,7 @@ export async function GET() {
       users: team.teamMembers.map((member) => ({
         ...member.user,
         teamRole: member.role,
-        mainEventRegistered: registeredEmailSet.has(member.user.email),
+        mainEventRegistered: registeredGithubUsernameSet.has(member.user.githubUsername),
       })),
     }));
 

--- a/app/services/eventbrite.ts
+++ b/app/services/eventbrite.ts
@@ -3,23 +3,24 @@ import { db } from "@/utils/db";
 import { preEventRegistrations } from "@/utils/db/schema/eventbrite";
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { sql } from "drizzle-orm";
+import { UserInfo } from "./user";
 
 export interface RegistrationStatus {
   preEventRegistered: boolean;
   mainEventRegistered: boolean;
 }
 
-export async function checkRegistrationStatus(email: string): Promise<RegistrationStatus> {
+export async function checkRegistrationStatus(user: UserInfo): Promise<RegistrationStatus> {
   try {
     const result = await db
       .select({
         preEventRegistered: sql<boolean>`EXISTS (
           SELECT 1 FROM ${preEventRegistrations}
-          WHERE ${preEventRegistrations.email} = ${email}
+          WHERE ${preEventRegistrations.email} = ${user.email}
         )`,
         mainEventRegistered: sql<boolean>`EXISTS (
           SELECT 1 FROM main_event_registrations
-          WHERE main_event_registrations.email = ${email}
+          WHERE SUBSTRING(main_event_registrations.github_profile_url FROM 'github.com/([^/]+)') = ${user.githubUsername}
         )`,
       })
       .from(sql`(SELECT 1) as dummy`);

--- a/app/services/team.ts
+++ b/app/services/team.ts
@@ -31,7 +31,7 @@ export async function getTeamById(teamId: string): Promise<Team | null> {
           )`,
           mainEventRegistered: sql<boolean>`EXISTS (
             SELECT 1 FROM main_event_registrations
-            WHERE main_event_registrations.email = ${user.email}
+            WHERE SUBSTRING(main_event_registrations.github_profile_url FROM 'github.com/([^/]+)') = ${user.githubUsername}
           )`,
         },
       })

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -47,7 +47,7 @@ export async function getAllUsersWithoutPagination(): Promise<UserInfo[]> {
                 )`,
         mainEventRegistered: sql<boolean>`EXISTS (
                     SELECT 1 FROM main_event_registrations
-                    WHERE main_event_registrations.email = ${user.email}
+                    WHERE SUBSTRING(main_event_registrations.github_profile_url FROM 'github.com/([^/]+)') = ${user.githubUsername}
                 )`,
       })
       .from(user)
@@ -110,7 +110,7 @@ export async function getUserById(userId: string): Promise<UserInfo | null> {
                 )`,
         mainEventRegistered: sql<boolean>`EXISTS (
                     SELECT 1 FROM main_event_registrations
-                    WHERE main_event_registrations.email = ${user.email}
+                    WHERE SUBSTRING(main_event_registrations.github_profile_url FROM 'github.com/([^/]+)') = ${user.githubUsername}
                 )`,
       })
       .from(user)
@@ -180,7 +180,7 @@ export async function getAllUsers(page = 1, pageSize = 10): Promise<PaginatedUse
             )`,
       mainEventRegistered: sql<boolean>`EXISTS (
                 SELECT 1 FROM main_event_registrations
-                WHERE main_event_registrations.email = ${user.email}
+                WHERE SUBSTRING(main_event_registrations.github_profile_url FROM 'github.com/([^/]+)') = ${user.githubUsername}
             )`,
     })
     .from(user)

--- a/app/user/home/page.tsx
+++ b/app/user/home/page.tsx
@@ -11,7 +11,7 @@ import { createClient } from "@/utils/supabase/server";
 import { Suspense } from "react";
 
 async function EventRegistrationStatus({ user }: { user: UserInfo }) {
-  const registrationStatus = await checkRegistrationStatus(user.email);
+  const registrationStatus = await checkRegistrationStatus(user);
 
   return (
     <div className="grid grow grid-cols-2 items-start justify-center p-8 text-center">

--- a/components/custom/admin/TeamManagement.tsx
+++ b/components/custom/admin/TeamManagement.tsx
@@ -54,7 +54,7 @@ export default function TeamManagement({
   const [internalSearchQuery, setInternalSearchQuery] = useState("");
   const [teamFilter, setTeamFilter] = useState<TeamFilter>("all");
   const [selectedChallengeId, setSelectedChallengeId] = useState<string>("all");
-  const [hideUnregisteredTeams, setHideUnregisteredTeams] = useState(true);
+  const [hideUnregisteredTeams, setHideUnregisteredTeams] = useState(false);
   const [showSubmittedTeamsOnly, setShowSubmittedTeamsOnly] = useState(false);
 
   // Use external search query if provided, otherwise use internal state

--- a/components/custom/admin/TeamManagement.tsx
+++ b/components/custom/admin/TeamManagement.tsx
@@ -378,6 +378,11 @@ export default function TeamManagement({
                           <span className="ml-1 text-sm text-neutral-500">
                             • {user.teamRole === "leader" ? "Leader" : "Member"}
                           </span>
+                          {!user.mainEventRegistered && (
+                            <span className="ml-1 text-sm font-medium text-red-600">
+                              • Not Registered
+                            </span>
+                          )}
                         </li>
                       ))}
                     </ul>

--- a/components/custom/admin/UserManagement.tsx
+++ b/components/custom/admin/UserManagement.tsx
@@ -178,7 +178,7 @@ export default function UserManagement({
 }: UserManagementProps) {
   const [currentPage, setCurrentPage] = useState(1);
   const [searchOpen, setSearchOpen] = useState(false);
-  const [hideUnregisteredUsers, setHideUnregisteredUsers] = useState(true);
+  const [hideUnregisteredUsers, setHideUnregisteredUsers] = useState(false);
   const [hideUsersWithTeams, setHideUsersWithTeams] = useState(false);
 
   // Filter users based on search

--- a/drizzle/0013_add_github_profile_url_unique_constraint.sql
+++ b/drizzle/0013_add_github_profile_url_unique_constraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "main_event_registrations" ADD CONSTRAINT "main_event_registrations_github_profile_url_unique" UNIQUE ("github_profile_url");
+CREATE UNIQUE INDEX IF NOT EXISTS "main_event_github_profile_url_idx" ON "main_event_registrations" ("github_profile_url"); 

--- a/drizzle/0013_unique-github-profile-url.sql
+++ b/drizzle/0013_unique-github-profile-url.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX "main_event_github_profile_url_idx" ON "main_event_registrations" USING btree ("github_profile_url");--> statement-breakpoint
+ALTER TABLE "main_event_registrations" ADD CONSTRAINT "main_event_registrations_github_profile_url_unique" UNIQUE("github_profile_url");

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,565 @@
+{
+  "id": "d5512152-5e33-4125-b6e1-b533814549fc",
+  "prevId": "456124db-92d4-4ca5-b407-15e640427c4d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOW()'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOW()'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.main_event_registrations": {
+      "name": "main_event_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_profile_url": {
+          "name": "github_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_profile_url": {
+          "name": "linkedin_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_team": {
+          "name": "has_team",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_email": {
+          "name": "ticket_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "main_event_email_idx": {
+          "name": "main_event_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "main_event_github_profile_url_idx": {
+          "name": "main_event_github_profile_url_idx",
+          "columns": [
+            {
+              "expression": "github_profile_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_name_idx": {
+          "name": "team_name_idx",
+          "columns": [
+            {
+              "expression": "team_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "main_event_registrations_email_unique": {
+          "name": "main_event_registrations_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "main_event_registrations_github_profile_url_unique": {
+          "name": "main_event_registrations_github_profile_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["github_profile_url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pre_event_registrations": {
+      "name": "pre_event_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendee_id": {
+          "name": "attendee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cell_phone": {
+          "name": "cell_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_in": {
+          "name": "checked_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_attendee_idx": {
+          "name": "event_attendee_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attendee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'participant'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_githubUsername_unique": {
+          "name": "user_githubUsername_unique",
+          "nullsNotDistinct": false,
+          "columns": ["githubUsername"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "role_verification": {
+          "name": "role_verification",
+          "value": "\"user\".\"role\" IN ('admin', 'participant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "leaderId": {
+          "name": "leaderId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challengeId": {
+          "name": "challengeId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission": {
+          "name": "submission",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_leaderId_user_id_fk": {
+          "name": "team_leaderId_user_id_fk",
+          "tableFrom": "team",
+          "tableTo": "user",
+          "columnsFrom": ["leaderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "team_challengeId_challenges_id_fk": {
+          "name": "team_challengeId_challenges_id_fk",
+          "tableFrom": "team",
+          "tableTo": "challenges",
+          "columnsFrom": ["challengeId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_name_unique": {
+          "name": "team_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "teamId": {
+          "name": "teamId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_teamId_team_id_fk": {
+          "name": "team_members_teamId_team_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "team",
+          "columnsFrom": ["teamId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "team_members_userId_user_id_fk": {
+          "name": "team_members_userId_user_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_teamId_userId_pk": {
+          "name": "team_members_teamId_userId_pk",
+          "columns": ["teamId", "userId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_member_role": {
+          "name": "check_member_role",
+          "value": "\"team_members\".\"role\" IN ('leader', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1739180706380,
       "tag": "0012_cute_iron_fist",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1739190526884,
+      "tag": "0013_unique-github-profile-url",
+      "breakpoints": true
     }
   ]
 }

--- a/utils/db/schema/eventbrite.ts
+++ b/utils/db/schema/eventbrite.ts
@@ -41,7 +41,7 @@ export const mainEventRegistrations = pgTable(
     firstName: text("first_name").notNull(),
     lastName: text("last_name").notNull(),
     email: text("email").notNull().unique(),
-    githubProfileUrl: text("github_profile_url"),
+    githubProfileUrl: text("github_profile_url").unique(),
     linkedinProfileUrl: text("linkedin_profile_url"),
     hasTeam: boolean("has_team").notNull(),
     teamName: text("team_name"),
@@ -52,6 +52,9 @@ export const mainEventRegistrations = pgTable(
   },
   (table) => ({
     emailIdx: uniqueIndex("main_event_email_idx").on(table.email),
+    githubProfileUrlIdx: uniqueIndex("main_event_github_profile_url_idx").on(
+      table.githubProfileUrl,
+    ),
     teamNameIdx: index("team_name_idx").on(table.teamName),
   }),
 );


### PR DESCRIPTION
## Description

The error was somehow eaten up in the logs in the previous version of the edge function, but this was the issue

```
Error creating registrations: {
  code: "42P10",
  details: null,
  hint: null,
  message: "there is no unique or exclusion constraint matching the ON CONFLICT specification"
}

```

Hence in this PR:
Adds a unique constraint and index on the `github_profile_url` column in the `main_event_registrations` table to ensure uniqueness and optimize lookups. Also updates the registration import function to handle duplicate GitHub profiles during data import.

## What is done

Drop all the rows that have duplicate github profile url then run `npx drizzle-kit push`.

```sql
DELETE FROM "public".main_event_registrations
WHERE github_profile_url IN (
    SELECT github_profile_url
    FROM "public".main_event_registrations
    GROUP BY github_profile_url
    HAVING COUNT(*) > 1
);
```

That should fix the issue of registrations not getting added.

---


