### PR TITLE
fix nav bar not closing on mobile viewport

### DIFF
--- a/components/custom/NavigationBar.tsx
+++ b/components/custom/NavigationBar.tsx
@@ -90,7 +90,11 @@ export default function NavigtionBar() {
                     animate={{ x: 0, opacity: 1 }}
                     exit={{ x: -20, opacity: 0 }}
                   >
-                    <Link href={link.href} className="text-white">
+                    <Link
+                      href={link.href}
+                      className="text-white"
+                      onClick={() => setExpandMobileNav(false)}
+                    >
                       {link.title}
                     </Link>
                   </motion.div>


### PR DESCRIPTION
n### TL;DR
Added functionality to close mobile navigation menu when a link is clicked.

### What changed?
Added an `onClick` event handler to the navigation `Link` component that sets `expandMobileNav` to `false` when a link is clicked.

### How to test?
1. Open the application on a mobile device or using mobile device emulation
2. Open the mobile navigation menu
3. Click on any navigation link
4. Verify that the mobile navigation menu closes automatically

### Why make this change?
Improves the mobile user experience by automatically closing the navigation menu after a user selects a destination, preventing the menu from remaining open and obscuring content on the new page.