### PR TITLE
update gap between challenge statements for larger viewports

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -83,7 +83,7 @@
   }
 }
 
-h1, h2, h3 {
+h1, h2, h3, h2 > span {
   font-family: var(--font-nexa);
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <main className="flex min-h-screen flex-col items-center">
             <div className="flex w-full flex-1 flex-col items-center">
               <div className="flex w-full flex-col">{children}</div>
-              <footer className="mx-auto flex w-full flex-col items-center justify-center gap-8 border-t bg-hackomania-red py-16 text-center text-xs text-white">
+              <footer className="mx-auto flex w-full flex-col items-center justify-center gap-8 border-t bg-hackomania-red py-4 text-center text-xs text-white md:py-8 lg:py-12">
                 <ContactSection />
                 {/* Hide theme switcher for now until we support dark mode design */}
                 {/* <ThemeSwitcher /> */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import GoldenRules from "@/components/custom/GoldenRules";
 import ImageCarousel from "@/components/custom/ImageCarousel/ImageCarousel";
 import NavigationBar from "@/components/custom/NavigationBar";
 import Organizers from "@/components/custom/Organizers";
-import Challenges from "@/components/custom/Challenges";
+import ChallengesSection from "@/components/custom/landing/ChallengesSection";
 import Prizes from "@/components/custom/Prizes";
 import Sponsors from "@/components/custom/Sponsors";
 import JudgesMentors from "@/components/custom/JudgesMentors";
@@ -193,7 +193,7 @@ export default async function Index() {
             />
             <h2>CHALLENGES</h2>
           </div>
-          <Challenges />
+          <ChallengesSection />
         </section>
 
         <section className="group py-10 intersect:animate-slide-in-from-left" id="judges">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,11 +101,17 @@ export default async function Index() {
         </div>
 
         <section className="group py-10 intersect:animate-slide-in-from-left" id="about">
-          <div className="mb-7 flex flex-row items-center gap-5 text-3xl font-bold text-hackomania-red md:mb-14 md:text-6xl">
+          <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-red md:mb-14 md:flex-row md:text-6xl">
             <Image src="/RedStar.svg" alt="" width={60} height={60} />
             <div>
-              <h2>HackOMania 2025:</h2>
-              <h2 className="text-2xl md:text-5xl">Healthy Living for a Connected World</h2>
+              <h2 className="flex flex-col gap-0 text-balance text-center md:text-start">
+                <span>
+                  HackOMania 2025<span className="hidden md:inline">:</span>
+                </span>
+                <span className="text-base md:text-2xl lg:text-5xl">
+                  Healthy Living for a Connected World
+                </span>
+              </h2>
             </div>
           </div>
 
@@ -183,7 +189,7 @@ export default async function Index() {
         </section>
 
         <section className="group py-10 intersect:animate-slide-in-from-right" id="challenges">
-          <div className="mb-7 flex flex-row items-center gap-3 fill-hackomania-green text-3xl font-bold text-hackomania-blue md:mb-14 md:text-6xl">
+          <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-blue md:mb-14 md:flex-row md:text-6xl">
             <Image
               src="/stickers/muscle.png"
               alt=""
@@ -191,23 +197,23 @@ export default async function Index() {
               height={80}
               className="rotate-[-6deg] hover:animate-wobble"
             />
-            <h2>CHALLENGES</h2>
+            <h2 className="text-balance text-center md:text-start">CHALLENGES</h2>
           </div>
           <ChallengesSection />
         </section>
 
         <section className="group py-10 intersect:animate-slide-in-from-left" id="judges">
-          <div className="mb-5 flex flex-row items-center gap-3 text-3xl font-bold text-hackomania-green md:mb-10 md:text-6xl">
+          <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-green md:mb-14 md:flex-row md:text-6xl">
             <Image src="/GreenStar.svg" alt="" width={60} height={60} />
-            <h2>JUDGES AND MENTORS</h2>
+            <h2 className="text-balance text-center md:text-start">JUDGES AND MENTORS</h2>
           </div>
           <JudgesMentors />
         </section>
 
         <section className="group py-10 intersect:animate-slide-in-from-right" id="prizes">
-          <div className="mb-7 flex flex-row items-center gap-3 fill-hackomania-green text-3xl font-bold text-hackomania-green md:mb-14 md:text-6xl">
+          <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-green md:mb-14 md:flex-row md:text-6xl">
             <Image src="/GreenStar.svg" alt="" width={60} height={60} />
-            <h2>PRIZES</h2>
+            <h2 className="text-balance text-center md:text-start">PRIZES</h2>
           </div>
           <PrizesSection />
         </section>
@@ -215,17 +221,17 @@ export default async function Index() {
         <TimelineSection />
 
         <section className="group py-10 intersect:animate-slide-in-from-left" id="golden-rules">
-          <div className="mb-5 flex flex-row items-center gap-3 text-3xl font-bold text-hackomania-blue md:mb-10 md:text-6xl">
+          <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-blue md:mb-14 md:flex-row md:text-6xl">
             <Image src="/BlueIcon.svg" alt="" width={60} height={60} />
-            <h2>7 GOLDEN RULES</h2>
+            <h2 className="text-balance text-center md:text-start">7 GOLDEN RULES</h2>
           </div>
           <GoldenRules />
         </section>
 
         <section className="group py-10 intersect:animate-slide-in-from-right" id="venue">
-          <div className="mb-5 flex flex-row items-center gap-3 text-3xl font-bold text-hackomania-green md:mb-10 md:text-6xl">
+          <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-green md:mb-14 md:flex-row md:text-6xl">
             <Image src="/GreenStar.svg" alt="" width={60} height={60} />
-            <h2>VENUE</h2>
+            <h2 className="text-balance text-center md:text-start">VENUE</h2>
           </div>
 
           <div>
@@ -309,15 +315,15 @@ export default async function Index() {
         </section>
 
         <section className="group py-8 intersect:animate-slide-in-from-left" id="sponsors">
-          <div className="mb-7 flex flex-row items-center gap-3 text-3xl font-bold text-hackomania-red md:mb-14 md:text-6xl">
+          <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-red md:mb-14 md:flex-row md:text-6xl">
             <Image src="/RedStar.svg" alt="" width={60} height={60} />
-            <h2>SPONSORS</h2>
+            <h2 className="text-balance text-center md:text-start">SPONSORS</h2>
           </div>
           <Sponsors />
         </section>
 
         <section className="group py-8 intersect:animate-slide-in-from-right" id="organizers">
-          <div className="mb-7 flex flex-row items-center gap-3 text-3xl font-bold text-hackomania-red md:mb-14 md:text-6xl">
+          <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-red md:mb-14 md:flex-row md:text-6xl">
             <Image
               src="/MeetTheTeam.svg"
               alt="Icon"
@@ -325,7 +331,7 @@ export default async function Index() {
               height={60}
               className="intersect:animate-spin-slow"
             />
-            <h2>Meet the Organizers</h2>
+            <h2 className="text-balance text-center md:text-start">Meet the Organizers</h2>
           </div>
           <OrganizersSection />
         </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import GitHubSignInButton from "@/components/custom/GitHubSignInButton";
 import GoldenRules from "@/components/custom/GoldenRules";
 import ImageCarousel from "@/components/custom/ImageCarousel/ImageCarousel";
 import NavigationBar from "@/components/custom/NavigationBar";
-import Organizers from "@/components/custom/Organizers";
+import OrganizersSection from "@/components/custom/landing/OrganizersSection";
 import ChallengesSection from "@/components/custom/landing/ChallengesSection";
 import PrizesSection from "@/components/custom/landing/PrizesSection";
 import Sponsors from "@/components/custom/Sponsors";
@@ -327,7 +327,7 @@ export default async function Index() {
             />
             <h2>Meet the Organizers</h2>
           </div>
-          <Organizers />
+          <OrganizersSection />
         </section>
       </div>
     </>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import ImageCarousel from "@/components/custom/ImageCarousel/ImageCarousel";
 import NavigationBar from "@/components/custom/NavigationBar";
 import Organizers from "@/components/custom/Organizers";
 import ChallengesSection from "@/components/custom/landing/ChallengesSection";
-import Prizes from "@/components/custom/Prizes";
+import PrizesSection from "@/components/custom/landing/PrizesSection";
 import Sponsors from "@/components/custom/Sponsors";
 import JudgesMentors from "@/components/custom/JudgesMentors";
 import TimelineSection from "@/components/custom/TimelineSection";
@@ -209,7 +209,7 @@ export default async function Index() {
             <Image src="/GreenStar.svg" alt="" width={60} height={60} />
             <h2>PRIZES</h2>
           </div>
-          <Prizes />
+          <PrizesSection />
         </section>
 
         <TimelineSection />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -100,7 +100,7 @@ export default async function Index() {
           </div>
         </div>
 
-        <section className="group py-10 intersect:animate-slide-in-from-left" id="about">
+        <section className="group relative py-10 intersect:animate-slide-in-from-left" id="about">
           <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-red md:mb-14 md:flex-row md:text-6xl">
             <Image src="/RedStar.svg" alt="" width={60} height={60} />
             <div>
@@ -186,9 +186,13 @@ export default async function Index() {
               </div>
             </div>
           </div>
+          <div className={`grid-bg absolute bottom-[-16px] h-96 w-full md:h-60`}></div>
         </section>
 
-        <section className="group py-10 intersect:animate-slide-in-from-right" id="challenges">
+        <section
+          className="group relative py-10 intersect:animate-slide-in-from-right"
+          id="challenges"
+        >
           <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-blue md:mb-14 md:flex-row md:text-6xl">
             <Image
               src="/stickers/muscle.png"
@@ -200,35 +204,42 @@ export default async function Index() {
             <h2 className="text-balance text-center md:text-start">CHALLENGES</h2>
           </div>
           <ChallengesSection />
+          <div className={`grid-bg absolute bottom-[-16px] h-96 w-full md:h-60`}></div>
         </section>
 
-        <section className="group py-10 intersect:animate-slide-in-from-left" id="judges">
+        <section className="group relative py-10 intersect:animate-slide-in-from-left" id="judges">
           <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-green md:mb-14 md:flex-row md:text-6xl">
             <Image src="/GreenStar.svg" alt="" width={60} height={60} />
             <h2 className="text-balance text-center md:text-start">JUDGES AND MENTORS</h2>
           </div>
           <JudgesMentors />
+          <div className={`grid-bg absolute bottom-[-16px] h-96 w-full md:h-60`}></div>
         </section>
 
-        <section className="group py-10 intersect:animate-slide-in-from-right" id="prizes">
+        <section className="group relative py-10 intersect:animate-slide-in-from-right" id="prizes">
           <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-green md:mb-14 md:flex-row md:text-6xl">
             <Image src="/GreenStar.svg" alt="" width={60} height={60} />
             <h2 className="text-balance text-center md:text-start">PRIZES</h2>
           </div>
           <PrizesSection />
+          <div className={`grid-bg absolute bottom-[-16px] h-96 w-full md:h-60`}></div>
         </section>
 
         <TimelineSection />
 
-        <section className="group py-10 intersect:animate-slide-in-from-left" id="golden-rules">
-          <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-blue md:mb-14 md:flex-row md:text-6xl">
+        <section
+          className="group relative py-10 intersect:animate-slide-in-from-left"
+          id="golden-rules"
+        >
+          <div className="lex flex-col items-center gap-5 text-3xl font-bold text-hackomania-blue md:flex-row md:text-6xl">
             <Image src="/BlueIcon.svg" alt="" width={60} height={60} />
             <h2 className="text-balance text-center md:text-start">7 GOLDEN RULES</h2>
           </div>
           <GoldenRules />
+          <div className={`grid-bg absolute bottom-[-16px] h-96 w-full md:h-60`}></div>
         </section>
 
-        <section className="group py-10 intersect:animate-slide-in-from-right" id="venue">
+        <section className="group relative py-10 intersect:animate-slide-in-from-right" id="venue">
           <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-green md:mb-14 md:flex-row md:text-6xl">
             <Image src="/GreenStar.svg" alt="" width={60} height={60} />
             <h2 className="text-balance text-center md:text-start">VENUE</h2>
@@ -312,17 +323,22 @@ export default async function Index() {
               </div>
             </div>
           </div>
+          <div className={`grid-bg absolute bottom-[-16px] h-96 w-full md:h-60`}></div>
         </section>
 
-        <section className="group py-8 intersect:animate-slide-in-from-left" id="sponsors">
+        <section className="group relative py-8 intersect:animate-slide-in-from-left" id="sponsors">
           <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-red md:mb-14 md:flex-row md:text-6xl">
             <Image src="/RedStar.svg" alt="" width={60} height={60} />
             <h2 className="text-balance text-center md:text-start">SPONSORS</h2>
           </div>
           <Sponsors />
+          <div className={`grid-bg absolute bottom-[-16px] h-96 w-full md:h-60`}></div>
         </section>
 
-        <section className="group py-8 intersect:animate-slide-in-from-right" id="organizers">
+        <section
+          className="group relative py-8 intersect:animate-slide-in-from-right"
+          id="organizers"
+        >
           <div className="mb-7 flex flex-col items-center gap-5 text-3xl font-bold text-hackomania-red md:mb-14 md:flex-row md:text-6xl">
             <Image
               src="/MeetTheTeam.svg"
@@ -334,6 +350,7 @@ export default async function Index() {
             <h2 className="text-balance text-center md:text-start">Meet the Organizers</h2>
           </div>
           <OrganizersSection />
+          <div className={`grid-bg absolute bottom-[-16px] h-96 w-full md:h-60`}></div>
         </section>
       </div>
     </>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import GitHubSignInButton from "@/components/custom/GitHubSignInButton";
-import GoldenRules from "@/components/custom/GoldenRules";
+import GoldenRulesSection from "@/components/custom/landing/GoldenRulesSection";
 import ImageCarousel from "@/components/custom/ImageCarousel/ImageCarousel";
 import NavigationBar from "@/components/custom/NavigationBar";
 import OrganizersSection from "@/components/custom/landing/OrganizersSection";
@@ -235,7 +235,7 @@ export default async function Index() {
             <Image src="/BlueIcon.svg" alt="" width={60} height={60} />
             <h2 className="text-balance text-center md:text-start">7 GOLDEN RULES</h2>
           </div>
-          <GoldenRules />
+          <GoldenRulesSection />
           <div className={`grid-bg absolute bottom-[-16px] h-96 w-full md:h-60`}></div>
         </section>
 

--- a/components/custom/NavigationBar.tsx
+++ b/components/custom/NavigationBar.tsx
@@ -52,7 +52,7 @@ export default function NavigtionBar() {
         animate={{ y: isVisible ? 0 : -100 }}
         transition={{ duration: 0.3 }}
       >
-        <div className="bg-hackomania-red p-5 lg:mx-20 lg:mt-10">
+        <div className="bg-hackomania-red p-5 shadow-lg lg:mx-20 lg:mt-10">
           <nav className="hidden flex-row justify-end gap-3 text-white md:flex" id="full-nav">
             {navigationLinks.map((link) => (
               <motion.div key={link.title} whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>

--- a/components/custom/NavigationBar.tsx
+++ b/components/custom/NavigationBar.tsx
@@ -52,7 +52,7 @@ export default function NavigtionBar() {
         animate={{ y: isVisible ? 0 : -100 }}
         transition={{ duration: 0.3 }}
       >
-        <div className="m-2 bg-hackomania-red p-5 md:mx-20 md:my-10">
+        <div className="bg-hackomania-red p-5 lg:mx-20 lg:mt-10">
           <nav className="hidden flex-row justify-end gap-3 text-white md:flex" id="full-nav">
             {navigationLinks.map((link) => (
               <motion.div key={link.title} whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>

--- a/components/custom/landing/ChallengesSection.tsx
+++ b/components/custom/landing/ChallengesSection.tsx
@@ -31,9 +31,9 @@ export const challengeStatements: Ichallenges[] = [
   },
 ];
 
-export default function Challenges() {
+export default function ChallengesSection() {
   return (
-    <div className="grid justify-center gap-2 md:gap-0">
+    <div className="grid justify-center gap-2 md:gap-16 lg:gap-24">
       {challengeStatements.map((challenge, index) => (
         <div
           key={index}
@@ -56,7 +56,7 @@ export default function Challenges() {
           {/* Challenge Statement */}
           <div className="flex flex-1 flex-col items-center gap-4 md:items-start">
             <p className="text-balance text-base font-bold md:text-xl">{challenge.statement}</p>
-            <p className="text-balance text-base font-medium md:text-xl">{challenge.description}</p>
+            <p className="text-balance text-base md:text-xl">{challenge.description}</p>
             <a
               href={challenge.pdf}
               target="_blank"

--- a/components/custom/landing/GoldenRulesSection.tsx
+++ b/components/custom/landing/GoldenRulesSection.tsx
@@ -52,10 +52,10 @@ function GoldenRule({ rule, title, index }: { rule: string; title: string; index
   );
 }
 
-export default function GoldenRules() {
+export default function GoldenRulesSection() {
   return (
     <ol
-      className="mt-5 grid grid-cols-1 gap-5 md:grid-cols-2 md:grid-rows-4 lg:grid-cols-3"
+      className="mt-5 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3"
       id="golden-rules-grid"
     >
       {goldenRules.map((rule, index) => (

--- a/components/custom/landing/OrganizersSection.tsx
+++ b/components/custom/landing/OrganizersSection.tsx
@@ -16,6 +16,7 @@ export default async function Organizers() {
 function Profile({ member }: { member: TeamMember }) {
   return (
     <div className="group/team relative h-40 max-w-full overflow-hidden rounded-xl bg-white md:h-[265px]">
+      <input type="checkbox" id={`overlay-toggle-${member.name}`} className="peer hidden" />
       <Image
         alt={member.name}
         src={`/team/images/${member.name.replace(" ", "").toLowerCase()}.jpg`}
@@ -25,21 +26,21 @@ function Profile({ member }: { member: TeamMember }) {
         unoptimized={true}
         aria-label={`Portrait of ${member.name}`}
       />
-      <div
-        id="details-overlay"
-        className="absolute left-0 top-0 z-10 h-full w-full overflow-hidden rounded-xl bg-black bg-opacity-40 p-5 text-white opacity-0 transition-opacity group-hover/team:opacity-100 group-focus/team:opacity-100"
+      <label
+        htmlFor={`overlay-toggle-${member.name}`}
+        className="absolute left-0 top-0 z-10 h-full w-full cursor-pointer overflow-hidden rounded-xl bg-black bg-opacity-40 p-3 text-white opacity-100 transition-opacity duration-300 ease-in-out peer-checked:opacity-0 md:cursor-default md:p-5 md:opacity-0 md:group-hover/team:opacity-100 md:group-focus/team:opacity-100 md:peer-checked:opacity-0"
       >
         <div className="flex h-full w-full flex-col">
           <div className="flex-grow"></div>
-          <p className="text-2xl font-bold md:text-3xl">{member.name}</p>
-          <p className="mb-3">
+          <p className="truncate text-lg font-bold md:text-2xl lg:text-3xl">{member.name}</p>
+          <p className="mb-2 truncate text-sm md:mb-3 md:text-base">
             {member.team} {member.role && `- ${member.role}`}
           </p>
-          <div className="flex flex-row gap-3">
+          <div className="flex flex-row gap-2 md:gap-3">
             {member.linkedin && (
               <Link href={member.linkedin} target="_blank" rel="noopener noreferrer">
                 <FaLinkedin
-                  className="text-2xl md:text-3xl"
+                  className="text-xl md:text-2xl lg:text-3xl"
                   aria-label={`LinkedIn of ${member.name}`}
                 />
               </Link>
@@ -47,7 +48,7 @@ function Profile({ member }: { member: TeamMember }) {
             {member.github && (
               <Link href={member.github} target="_blank" rel="noopener noreferrer">
                 <FaGithub
-                  className="text-2xl md:text-3xl"
+                  className="text-xl md:text-2xl lg:text-3xl"
                   aria-label={`GitHub of ${member.name}`}
                 />
               </Link>
@@ -55,14 +56,14 @@ function Profile({ member }: { member: TeamMember }) {
             {member.twitter && (
               <Link href={member.twitter} target="_blank" rel="noopener noreferrer">
                 <FaTwitter
-                  className="text-2xl md:text-3xl"
+                  className="text-xl md:text-2xl lg:text-3xl"
                   aria-label={`Twitter of ${member.name}`}
                 />
               </Link>
             )}
           </div>
         </div>
-      </div>
+      </label>
     </div>
   );
 }

--- a/components/custom/landing/PrizesSection.tsx
+++ b/components/custom/landing/PrizesSection.tsx
@@ -10,7 +10,6 @@ const prizes = [
     img: "/prizes/Champion.svg",
     width: 150,
     height: 150,
-    titleClassName: "text-2xl md:text-4xl text-center",
   },
   {
     title: "Challenge 2 Winner",
@@ -18,7 +17,6 @@ const prizes = [
     img: "/prizes/Champion.svg",
     width: 150,
     height: 150,
-    titleClassName: "text-2xl md:text-4xl text-center",
   },
   {
     title: "Challenge 3 Winner",
@@ -26,7 +24,6 @@ const prizes = [
     img: "/prizes/Champion.svg",
     width: 150,
     height: 150,
-    titleClassName: "text-2xl md:text-4xl text-center",
   },
   {
     title: "People's Choice",
@@ -34,7 +31,6 @@ const prizes = [
     img: "/prizes/PeopleChoice.svg",
     width: 150,
     height: 150,
-    titleClassName: "text-2xl md:text-4xl text-center",
   },
 ];
 
@@ -43,14 +39,13 @@ interface PrizeProps {
   title: string;
   width: number;
   height: number;
-  titleClassName?: string;
   amount: string;
 }
 
-function Prize({ img, title, width, height, titleClassName, amount }: PrizeProps) {
+function Prize({ img, title, width, height, amount }: PrizeProps) {
   return (
     <motion.div
-      className="flex flex-col items-center gap-3 font-bold text-hackomania-green"
+      className="flex flex-col items-center gap-3 p-4 font-bold text-hackomania-green"
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
@@ -64,24 +59,23 @@ function Prize({ img, title, width, height, titleClassName, amount }: PrizeProps
         height={height}
         style={{
           maxWidth: `${width}px`,
-          width: "100%",
-          height: "auto",
         }}
         priority
       />
-      <h3 className={titleClassName}>{title}</h3>
-      <p className="text-xl md:text-3xl">{amount}</p>
+      <h3 className="text-center text-2xl md:text-3xl">{title}</h3>
+      <p className="text-xl md:text-2xl">{amount}</p>
     </motion.div>
   );
 }
 
-export default function Prizes() {
+export default function PrizesSection() {
   return (
-    <div className="flex flex-col gap-12">
-      <div className="flex flex-col justify-center gap-10 md:mt-14 md:flex-row md:gap-20">
+    <div className="flex flex-col gap-12 px-8 md:py-14">
+      <div className="flex w-full flex-col justify-center gap-10 md:flex-row md:gap-20">
         {prizes.slice(0, 3).map((prize, index) => (
           <motion.div
             key={prize.title}
+            className="min-w-0 flex-1"
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
@@ -95,7 +89,7 @@ export default function Prizes() {
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
-        transition={{ duration: 0.5 }}
+        transition={{ duration: 0.5, delay: 3 * 0.2 }}
       >
         <Prize {...prizes[3]} />
       </motion.div>


### PR DESCRIPTION
update gap between challenge statements for larger viewports

improve nav bar for viewports below lg

improve prizes section in viewports smaller than lg

improve organizers section in viewports smaller than lg

style(layout.tsx): adjust footer padding to improve visual consistency on different screen sizes

style(NavigationBar.tsx): add shadow to the navigation bar to improve visual appearance

improve styling of section headers on mobile viewports

feat(page.tsx): add grid background to sections for visual enhancement and separation of content

remove margin in Golden Rules section